### PR TITLE
feat(security): harden Linux execution and signed receipts

### DIFF
--- a/.github/workflows/privileged.yml
+++ b/.github/workflows/privileged.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y dwarves libssl-dev nftables pkg-config protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y crun dwarves jq libssl-dev nftables pkg-config protobuf-compiler
 
       - name: Install nightly Rust
         run: rustup toolchain install nightly --component rust-src

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ The product hierarchy is load-bearing:
 
 Do not present Rauha as primarily an eBPF project or a Kubernetes runtime. Rauha creates the zones. Syva makes the Linux kernel respect them. Current Linux eBPF code may still live in this repository, but architecturally it belongs behind the Syva enforcement boundary.
 
+Product direction (see `docs/positioning-and-roadmap.md`): the zone is the boundary, the **run** is the product — `rauha run -- <agent cmd>` with fork/compare/accept is planned, `rauha sandbox` is what ships. README claims must be shipped or explicitly marked planned. `docs/architecture.md` holds the diagram, crate map, and full control surface.
+
 ## Build & Test Commands
 
 ```bash
@@ -21,6 +23,8 @@ cargo build                          # Build all workspace crates
 cargo test                           # Run all unit tests
 cargo test -p rauha-oci              # Test a single crate
 cargo test test_name                 # Run a single test by name
+cargo fmt --all -- --check           # CI gate
+cargo clippy --workspace --all-targets -- -D warnings   # CI gate
 cargo build --bin rauhad             # Build just the daemon
 cargo build --bin rauha              # Build just the CLI
 cargo build --bin rauha-shim         # Build the per-zone shim
@@ -46,8 +50,10 @@ cargo run --bin rauha -- zone list
 cargo run --bin rauha -- image pull alpine:latest
 cargo run --bin rauha -- run --zone test alpine:latest /bin/echo hello
 
-# Agent sandbox task (primary product shape — API contract, runtime still landing)
+# Agent sandbox task (primary product shape; implemented end to end)
 cargo run --bin rauha -- sandbox --image alpine:latest -- /bin/echo hello
+cargo run --bin rauha -- sandbox --image alpine:latest --audit --keep-zone -- /bin/sh -c id
+cargo run --bin rauha -- zone verify test --json   # boundary self-check (named checks, passed/detail)
 
 # Observability / evidence surface
 cargo run --bin rauha -- trace --zone test          # syscall trace for a zone
@@ -65,7 +71,15 @@ bash tests/integration/test-zone-networking.sh
 bash tests/integration/test-exec.sh
 bash tests/integration/test-logs.sh
 bash tests/integration/test-sandbox.sh         # agent sandbox task end-to-end
+bash tests/integration/test-host-boundaries.sh # adversarial host-impact probes
 bash tests/integration/test-cgroup-lock.sh          # eBPF enforcement required
+
+# Authoritative privileged security gate (Linux, BPF-LSM kernel, passwordless sudo, crun, jq):
+# fmt + clippy + tests + eBPF build, then daemon, every integration test, the crash-recovery
+# probe (kill -9 rauhad mid-workload, restart, verify PID/cgroup/inode ownership survive),
+# the crun executor probe, and the oracle. This is the Sykli `full` task (sykli.json).
+bash tests/security/linux-gate.sh
+bash tests/security/run.sh --gate      # same, via Sykli on this host or one running Lima VM (RAUHA_LIMA_INSTANCE)
 
 # Oracle tests (require running rauhad, any platform)
 cd eval/oracle
@@ -102,13 +116,20 @@ Both platform backends implement this trait. rauhad is platform-agnostic — it 
 
 ### One Shim Per Zone (Not Per Container)
 
-This diverges from containerd's one-shim-per-container model. Zones are the isolation boundary, not containers. Multiple containers in a zone share namespaces. rauhad spawns one `rauha-shim` per zone; the shim forks additional container processes on request. Shim binary search: same directory as rauhad, then `target/debug/`, `target/release/`, then `/usr/local/bin`, `/usr/bin`. Socket at `/run/rauha/shim-{zone_name}.sock` — rauhad polls for up to 5 seconds after spawning.
+This diverges from containerd's one-shim-per-container model. Zones are the isolation boundary, not containers. Multiple containers in a zone share namespaces. rauhad spawns one `rauha-shim` per zone; the shim supervises one crun-created init per container on request, and remains the zone lifecycle and evidence bridge. Shim binary search: same directory as rauhad, then `target/debug/`, `target/release/`, then `/usr/local/bin`, `/usr/bin`. Socket at `/run/rauha/shim-{zone_name}.sock` — rauhad polls for up to 5 seconds after spawning.
 
-### Container Fork Flow (Linux)
+### Container Start Flow (Linux): crun + enrollment before start
 
-The sync pipe pattern in `rauha-shim/src/container.rs` prevents a TOCTOU race: the child must be in the zone's cgroup **before** it runs, otherwise eBPF enforcement doesn't apply. Parent writes child PID to cgroup, then signals the pipe; child blocks until confirmed.
+The shim no longer builds containers itself; `rauha-shim/src/container.rs` delegates OCI construction to `/usr/bin/crun` (required, `--cgroup-manager=disabled` so Rauha keeps cgroup ownership). The order is the security invariant — no image code may run before the process is in the zone cgroup, otherwise eBPF enforcement doesn't apply:
 
-**Fork-safety invariant:** All code after `fork()` in the child must be async-signal-safe. This means: no `std::env::set_var`/`vars` (holds a global mutex), no `eprintln!`/`panic!` (Rust panic machinery), no heap allocation. Use `libc::putenv` with pre-allocated `CString`s, `libc::write` for output, and `libc::_exit` instead of `std::process::exit`. Pre-allocate all strings and paths before fork.
+1. `crun create --bundle … --pid-file init.pid` — crun does all privileged setup (namespaces, mounts, pivot_root, capability drop, seccomp) and parks init on its `exec.fifo`. This setup runs *outside* the zone cgroup, so the eBPF `capable` hook does not judge crun's own `CAP_SYS_ADMIN` work against the workload policy.
+2. Read `init.pid`, `pidfd_open` it (the pidfd is held for the container's lifetime; signal via `pidfd_send_signal`, wait via `poll` on the pidfd — immune to PID reuse).
+3. Write the PID to `/sys/fs/cgroup/rauha.slice/zone-{name}/cgroup.procs`. Failure → `crun delete --force`, fail closed.
+4. `crun start` — only now does init `execve` the image entrypoint, inside the boundary.
+
+Never enroll via OCI `startContainer` hooks: crun runs them after pivot_root and privilege drop, resolving `path` in the *image* rootfs — untrusted code with no `CAP_SYS_ADMIN`. `createRuntime` hooks (host binary, state JSON on stdin) are the spec-blessed alternative if a hook is ever needed. Analysis and crun source references: `docs/positioning-and-roadmap.md` § Enrollment.
+
+**Fork-safety invariant (still applies to `attach.rs` exec/PTY paths and the macOS guest agent):** all code after `fork()`/`clone3()` in the child must be async-signal-safe — no `std::env::set_var`/`vars`, no `eprintln!`/`panic!`, no heap allocation. Use `libc::putenv` with pre-allocated `CString`s, `libc::write` for output, and `libc::_exit`. Pre-allocate all strings and paths before fork.
 
 ### macOS Backend: VM-Per-Zone (`rauhad/src/backend/macos/`)
 
@@ -188,6 +209,14 @@ Don't extend `rauha-enforce/` — new enforcement work goes in the syva repo. Bu
 
 What's still documented here for context: it loaded the same eBPF LSM programs as rauhad, used label-driven zone assignment via the `rauha.dev/zone` OCI annotation, and refused to load if BPF maps were already pinned at `/sys/fs/bpf/rauha/` (mutual exclusion with rauhad).
 
+### Policy Admission: enforced, audited, or refused (`rauhad/src/backend/linux/mod.rs`)
+
+`ZonePolicy.admission` is `strict` (default) or `audit` (`policies/audit.toml`). At zone creation `admit_linux_policy()` classifies every requested control; `unsupported_linux_controls()` currently lists `filesystem.writable_paths` (unless a safe path), `devices.allowed`, `syscalls.deny`, plus any LSM hook the kernel skipped (`lsm.<hook>`). Strict admission **refuses** the zone with the control names in the error; audit admits it, records the names in `zone_degradations`, and they surface as `policy:<control>` checks in `zone verify` and as `unavailable_controls` in the sandbox result. The Linux daemon itself fails closed at startup (root + BPF-LSM required, no degraded mode) — `audit` only relaxes per-zone policy controls, never enforcement presence.
+
+`verify_isolation()` (`rauha zone verify --json`) emits named checks — `policy:admitted`, `cgroup`, `ebpf:health`, `bpf_membership`, `filesystem:inode_ownership`, `netns`, `network:veth`, `network:nftables` — each with `passed` and `detail`. The security probes (`tests/security/*.sh`) key on these names; adding a control means adding a check here, not just a code path.
+
+`rauha-enforcer-api` defines the enforcement boundary as a backend-neutral async trait (`EnforcerBackend`: `register_zone`, `attach_container`, `register_host_path`, `verify`, `capabilities`, …) with `NoopEnforcer` as the honesty baseline and a shared conformance harness. Today `LinuxBackend` still drives the in-repo `LinuxEnforcer` through inherent id-keyed methods (sync `IsolationBackend` vs. async trait); the seam is real but not yet the sole enforcement path. See `docs/rauha-product-abilities.md`.
+
 ### gRPC Error Boundary (`rauhad/src/server.rs`)
 
 `to_status()` maps `RauhaError` variants to correct gRPC status codes. When adding new error variants, update this function — the oracle will catch incorrect mappings. Key mappings: `ZoneNotFound`/`ContainerNotFound`/`ImageNotFound`→`NotFound`, `ZoneAlreadyExists`/`ContainerAlreadyExists`→`AlreadyExists`, `InvalidInput`/`InvalidPolicy`→`InvalidArgument`, `PermissionDenied`/`CrossZoneAccessDenied`→`PermissionDenied`, `ZoneNotEmpty`→`FailedPrecondition`.
@@ -227,10 +256,11 @@ Built separately via `cargo xtask build-ebpf` targeting `bpfel-unknown-none`. Re
 
 | Crate | Purpose |
 |-------|---------|
-| `rauha-common` | Shared types, `IsolationBackend` trait, error types, policy parsing, shim IPC protocol |
+| `rauha-common` | Shared types, `IsolationBackend` trait, error types, policy parsing, sandbox result types, shim IPC protocol |
+| `rauha-enforcer-api` | `EnforcerBackend` trait, kernel-facing policy/event types, `Capabilities`, `NoopEnforcer`, shared conformance harness |
 | `rauhad` | Daemon — gRPC server, zone registry, metadata (redb), networking, Linux/macOS backends |
 | `rauha-cli` | CLI binary — connects to rauhad via gRPC |
-| `rauha-shim` | Per-zone sync process — fork/run containers (Linux only) |
+| `rauha-shim` | Per-zone sync supervisor (Linux only) — crun create/enroll/start per container, pidfd lifetime, exec/attach |
 | `rauha-guest-agent` | Guest-side daemon inside macOS VMs — container lifecycle over virtio-vsock |
 | `rauha-oci` | OCI image pull, content store, rootfs preparation, runtime spec generation |
 | `rauha-evidence` | Evidence-grade observability schema, projections, and sinks. Normalizes Syva/backend enforcement records + Rauha lifecycle events into one schema. Does not enforce. Consumed only by `rauhad`. |
@@ -239,6 +269,11 @@ Built separately via `cargo xtask build-ebpf` targeting `bpfel-unknown-none`. Re
 | `rauha-ebpf` | eBPF LSM programs (kernel-side, not in workspace, separate build) |
 | `rauha-ebpf-common` | Shared `#[repr(C)]` types between eBPF programs and userspace |
 | `xtask` | Build helper for eBPF compilation |
+
+## Work tooling in this repo
+
+- `sykli.json` / `sykli.lock` — the locked Sykli work graph; its single `full` task is the privileged security gate above. Changes to `tests/security/linux-gate.sh` usually go together with these two files.
+- `.toimija/` — Toimija session packets (the workset contract shown at session start). `.toimija/current.*`, `sessions/`, `runs/` are gitignored; `history.*` currently is not. Run `toimija verify` before committing; declare reads outside the packet's workset with `toimija intent "<why>" --scope <path>`.
 
 ## Oracle (`eval/oracle/`)
 
@@ -253,6 +288,7 @@ The oracle must not be modified as a side effect of modifying the system. It has
 - Linux 6.1+ with `CONFIG_BPF_LSM=y`, `CONFIG_BPF_SYSCALL=y`, `CONFIG_DEBUG_INFO_BTF=y`
 - Boot parameter: `lsm=lockdown,capability,bpf`
 - BTF at `/sys/kernel/btf/vmlinux`
+- `crun` at `/usr/bin/crun` (container construction is delegated to it); `jq` for the security probes
 
 ### macOS (Virtualization.framework)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert_matches"
@@ -938,7 +938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1173,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1413,7 +1413,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1605,7 +1605,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2470,9 +2470,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2857,7 +2857,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3255,7 +3255,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4015,7 +4015,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -85,7 +85,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -261,6 +261,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -452,6 +458,12 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "containerd-client"
@@ -700,6 +712,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +771,16 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -820,6 +869,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,7 +938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -873,6 +946,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -1526,7 +1605,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2083,6 +2162,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,6 +2507,7 @@ dependencies = [
  "libc",
  "prost 0.13.5",
  "rauha-common",
+ "rauha-evidence",
  "serde",
  "serde_json",
  "tokio",
@@ -2490,8 +2580,13 @@ name = "rauha-evidence"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "ed25519-dalek",
+ "hex",
+ "libc",
  "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2762,7 +2857,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2974,6 +3069,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,6 +3122,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3141,7 +3255,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3901,7 +4015,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ chrono = { version = "0.4", features = ["serde"] }
 bytes = "1"
 sha2 = "0.10"
 hex = "0.4"
+ed25519-dalek = "2"
 
 # Platform-specific (Linux)
 [workspace.dependencies.nix]

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ across machines and teams. The full reasoning, market survey, and hardening road
 
 `rauhad` is a platform-agnostic daemon behind one `IsolationBackend` trait; the
 `rauha` CLI and `containerd-shim-rauha-v2` are thin gRPC clients. On Linux,
-`rauhad` spawns one `rauha-shim` per zone, which starts each container process
-and keeps lifecycle, logs, exec IPC, and evidence together. Zones get
+`rauhad` spawns one `rauha-shim` per zone, which supervises `crun` for each
+container and keeps lifecycle, logs, exec IPC, and evidence together. Zones get
 their own network namespace, an IP on the `rauha0` bridge, and nftables rules
 that default to drop. On macOS the zone is a Virtualization.framework VM with an
 APFS-cloned rootfs and a guest agent over vsock.
@@ -199,9 +199,8 @@ Three layers of verification, each independent of the source:
 
 In order:
 
-1. Delegate Linux container construction to `crun` with trusted enrollment —
-   no image code runs before the process is inside its zone; init and exec
-   treated identically.
+1. Finish safe user-namespace support on a runtime/storage combination that can
+   make the rootfs private after entering the target user namespace.
 2. Run Protocol v0 — the journal, reducer, lifecycle, ownership epochs,
    capability intents, checkpoints, forks, and adoption.
 3. Local custodian and tier-0 supervisor with three built-in services:

--- a/containerd-shim-rauha-v2/build.rs
+++ b/containerd-shim-rauha-v2/build.rs
@@ -2,6 +2,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_server(false)
         .build_client(true)
+        .client_mod_attribute(
+            ".",
+            "#[allow(clippy::mixed_attributes_style, clippy::result_large_err)]",
+        )
         .compile_protos(
             &[
                 "../proto/zone.proto",

--- a/docs/positioning-and-roadmap.md
+++ b/docs/positioning-and-roadmap.md
@@ -80,35 +80,31 @@ Sources: [gVisor perf](https://gvisor.dev/docs/architecture_guide/performance/),
 
 Verified against crun `src/libcrun/container.c` (main, 2026-08-27):
 `startContainer` hooks are forked by init **after** `pivot_root`, `setresuid`,
-capability drop, and seccomp, and `path` resolves in the image rootfs. So the
-hook on the in-flight crun executor branch (`sh -c "printf 1 >
-/run/rauha-zone.procs"`) runs the image's
-`/bin/sh` with workload privileges, and a hostile image can skip enrollment
-entirely. No trusted binary can be placed there either — the hook has no
-`CAP_SYS_ADMIN` and may be seccomp-blocked. `startContainer` is a dead end for
-enrollment in any runtime (runc sequences it the same way).
+capability drop, and seccomp, and `path` resolves in the image rootfs. A hook
+there runs the image's `/bin/sh` with workload privileges, so a hostile image
+can skip enrollment entirely, and no trusted binary can be placed there either —
+the hook has no `CAP_SYS_ADMIN` and may be seccomp-blocked. `startContainer` is
+a dead end for enrollment in any runtime (runc sequences it the same way).
+
+What the shim does (`rauha-shim/src/container.rs`): `crun create --pid-file`
+(all privileged setup, init parked on `exec.fifo`, outside the zone cgroup) →
+`pidfd_open` → write `cgroup.procs`, fail closed on error → `crun start`. No
+image code runs before enrollment; the pidfd makes signal/wait immune to PID
+reuse.
 
 | Option | Verdict |
 |---|---|
-| `startContainer` hook (in-flight branch) | fail-open; untrusted code before enrollment |
+| `startContainer` hook | fail-open; untrusted code before enrollment — never |
 | Trusted static helper in `startContainer` | cannot work: runs after privilege drop |
-| `createRuntime` hook, host binary, reads state JSON `pid` | spec-blessed (nvidia pattern); works with `crun create`+`start` because init is parked on `exec.fifo`; fallback only |
-| **`--cgroup-manager=cgroupfs` + `"cgroupsPath": "/rauha.slice/zone-X"`** | crun passes the zone cgroup dirfd to `clone3(CLONE_INTO_CGROUP)`: init is *born* enrolled, `crun exec` enrolls too, no hook at all |
+| **`crun create` → pidfd → `cgroup.procs` → `crun start`** (current) | enrollment while init is parked; crun setup judged outside the zone; one `cgroup.procs` write, fail closed |
+| `createRuntime` hook, host binary, reads state JSON `pid` | spec-blessed (nvidia pattern); equivalent to the current flow if a hook is ever required |
+| `--cgroup-manager=cgroupfs` + `"cgroupsPath": "/rauha.slice/zone-X"` | crun passes the zone cgroup dirfd to `clone3(CLONE_INTO_CGROUP)`: zero window and `crun exec` enrolls too — but crun's privileged setup then runs *inside* the zone cgroup, so Syva would need a `bprm_check_security`-keyed phase gate (audit before the workload's first exec, deny after) in `capable`/`file_open` |
 | Post-hoc `/proc/pid/cgroup` (or `PIDFD_GET_INFO` cgroupid, 6.13+) | not enforcement; keep as the invariant check |
 
-**Recommendation:** `cgroupsPath` + `CLONE_INTO_CGROUP` for enrollment,
-`crun create` + `crun start` instead of `run` so the shim can `pidfd_open` and
-verify the cgroup while init is still parked on `exec.fifo`, post-hoc check as
-the invariant, `createRuntime` host-hook as the pre-5.7 fallback.
-
-The consequence for Syva: crun's privileged setup (mounts, pivot, setuid, cap
-drop, seccomp) now runs *inside* the zone cgroup. A cgroup-keyed deny-by-default
-`capable` hook would break container creation. The LSM needs a phase gate: on
-the first successful `bprm_check_security` for a task in a zone cgroup, mark the
-task (task-local storage) as "workload"; `capable`/`file_open` deny only for
-workload-phase tasks and audit (not deny) before that. This preserves the old
-shim's invariant — trusted setup outside the policy, untrusted code inside — with
-zero enrollment window and no sync pipe.
+The `cgroupsPath` variant is the upgrade if exec-path enrollment or a zero-write
+sequence is ever needed; it is not required while the create/enroll/start
+sequence holds. Any change to the start path must keep enrollment strictly
+between `create` and `start`, and a hostile-image probe is the right test.
 
 Crun details to handle: omit `linux.resources` from the spec (Rauha owns limits);
 `crun delete` will try to `rmdir` the zone cgroup and get `EBUSY` — verify it is
@@ -170,9 +166,9 @@ user-namespace, Landlock, or pidfd code. These close those gaps, cheapest first.
 
 ## Suggested sequencing
 
-1. Enrollment fix (`cgroupsPath`/`CLONE_INTO_CGROUP` + create/start + pidfd +
-   Syva phase gate) with a hostile-image probe — this unblocks `obl_executor`
-   and `obl_hardening` honestly.
+1. Land the crun executor (create → pidfd → enroll → start) on `main` with a
+   hostile-image probe that proves nothing runs before enrollment — this closes
+   `obl_executor` honestly and is the precondition for `obl_hardening`.
 2. Items 1–4 above (cgroup basics, safe rootfs, pidfd, seccomp): closes
    `syscalls.deny`; all ≤5.14 so no baseline change.
 3. Landlock + userns + cgroup device BPF: closes `writable_paths` and

--- a/eval/oracle/build.rs
+++ b/eval/oracle/build.rs
@@ -5,6 +5,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     tonic_build::configure()
         .build_server(false)
+        .client_mod_attribute(
+            ".",
+            "#[allow(clippy::mixed_attributes_style, clippy::result_large_err)]",
+        )
         .compile_protos(
             &[
                 "proto/zone.proto",

--- a/eval/oracle/src/main.rs
+++ b/eval/oracle/src/main.rs
@@ -61,6 +61,14 @@ mod helpers {
             .unwrap_or_else(|_| "http://[::1]:9876".into())
     }
 
+    pub fn test_image() -> String {
+        std::env::var("TEST_IMAGE").unwrap_or_else(|_| "alpine:latest".into())
+    }
+
+    pub fn test_secondary_image() -> String {
+        std::env::var("TEST_SECONDARY_IMAGE").unwrap_or_else(|_| "busybox:latest".into())
+    }
+
     // --- Settlement constants ---
 
     /// Zone creation: cgroup + netns + veth + BPF map + IP assignment.
@@ -240,7 +248,7 @@ memory_limit = "{mem}"
     pub async fn ensure_alpine(client: &mut pb::image::image_service_client::ImageServiceClient<Channel>) {
         let mut stream = client
             .pull(pb::image::PullRequest {
-                reference: "alpine:latest".into(),
+                reference: test_image(),
             })
             .await
             .expect("Pull must succeed")
@@ -261,7 +269,7 @@ memory_limit = "{mem}"
             .create_container(pb::container::CreateContainerRequest {
                 zone_name: zone_name.into(),
                 name: name.into(),
-                image: "alpine:latest".into(),
+                image: test_image(),
                 command,
                 env: Default::default(),
                 working_dir: String::new(),
@@ -459,7 +467,7 @@ mod container_lifecycle {
             .create_container(pb::container::CreateContainerRequest {
                 zone_name: "oracle-005-nonexistent".into(),
                 name: "orphan".into(),
-                image: "alpine:latest".into(),
+                image: test_image(),
                 command: vec!["/bin/true".into()],
                 env: Default::default(),
                 working_dir: String::new(),
@@ -485,7 +493,7 @@ mod container_lifecycle {
             .create_container(pb::container::CreateContainerRequest {
                 zone_name: zone_name.clone(),
                 name: "echo-test".into(),
-                image: "alpine:latest".into(),
+                image: test_image(),
                 command: vec!["/bin/echo".into(), "hello-oracle".into()],
                 env: Default::default(),
                 working_dir: String::new(),
@@ -557,7 +565,7 @@ mod image_management {
 
         let inspect = client
             .inspect(pb::image::InspectImageRequest {
-                reference: "alpine:latest".into(),
+                reference: test_image(),
             })
             .await
             .expect("Inspect must succeed")
@@ -588,12 +596,12 @@ mod image_management {
     #[tokio::test]
     async fn case_009_remove_image() {
         let mut client = image_client().await;
-        let image_ref = "busybox:latest";
+        let image_ref = test_secondary_image();
 
         // Pull busybox for this test.
         let mut stream = client
             .pull(pb::image::PullRequest {
-                reference: image_ref.into(),
+                reference: image_ref.clone(),
             })
             .await
             .expect("Pull must succeed")
@@ -606,7 +614,7 @@ mod image_management {
         // Verify it's there before removing.
         client
             .inspect(pb::image::InspectImageRequest {
-                reference: image_ref.into(),
+                reference: image_ref.clone(),
             })
             .await
             .expect("busybox must be inspectable before remove");
@@ -614,7 +622,7 @@ mod image_management {
         // Remove.
         client
             .remove(pb::image::RemoveImageRequest {
-                reference: image_ref.into(),
+                reference: image_ref.clone(),
             })
             .await
             .expect("Remove must succeed");
@@ -624,7 +632,7 @@ mod image_management {
         // Inspect must now fail.
         let result = client
             .inspect(pb::image::InspectImageRequest {
-                reference: image_ref.into(),
+                reference: image_ref,
             })
             .await;
 
@@ -1549,11 +1557,11 @@ mod invariants {
         ensure_alpine(&mut client).await;
 
         let inspect1 = client
-            .inspect(pb::image::InspectImageRequest { reference: "alpine:latest".into() })
+            .inspect(pb::image::InspectImageRequest { reference: test_image() })
             .await.expect("Inspect 1 must succeed").into_inner();
 
         let inspect2 = client
-            .inspect(pb::image::InspectImageRequest { reference: "alpine:latest".into() })
+            .inspect(pb::image::InspectImageRequest { reference: test_image() })
             .await.expect("Inspect 2 must succeed").into_inner();
 
         assert_eq!(inspect1.digest, inspect2.digest, "digest must be stable across inspects");
@@ -1780,7 +1788,7 @@ mod stress {
 
         let mut stream = client
             .pull(pb::image::PullRequest {
-                reference: "alpine:latest".into(),
+                reference: test_image(),
             })
             .await
             .expect("Pull must succeed")

--- a/eval/wasm-tier-probe.sh
+++ b/eval/wasm-tier-probe.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Measure crun's existing Wasm handler without adding a runtime to Rauha.
+set -euo pipefail
+
+ITERATIONS=${ITERATIONS:-10}
+BUNDLE=$(mktemp -d "${TMPDIR:-/tmp}/rauha-wasm-tier.XXXXXX")
+RUNTIME_ROOT="$BUNDLE/runtime"
+WASM_HEX=0061736d0100000001040160000003020100070a01065f737461727400000a040102000b
+
+cleanup() {
+    for iteration in $(seq 1 "$ITERATIONS"); do
+        crun --root "$RUNTIME_ROOT" --cgroup-manager=disabled delete --force "rauha-wasm-$iteration" >/dev/null 2>&1 || true
+    done
+    case "$BUNDLE" in
+        "${TMPDIR:-/tmp}"/rauha-wasm-tier.*) rm -rf -- "$BUNDLE" ;;
+        *) echo "refusing to remove unexpected bundle: $BUNDLE" >&2 ;;
+    esac
+}
+trap cleanup EXIT
+
+mkdir -p "$BUNDLE/rootfs" "$RUNTIME_ROOT"
+python3 -c 'import sys; sys.stdout.buffer.write(bytes.fromhex(sys.argv[1]))' "$WASM_HEX" >"$BUNDLE/rootfs/probe.wasm"
+printf '%s\n' '{"ociVersion":"1.0.2","annotations":{"run.oci.handler":"wasm"},"process":{"terminal":false,"user":{"uid":0,"gid":0},"args":["/probe.wasm"],"env":[],"cwd":"/","noNewPrivileges":true},"root":{"path":"rootfs","readonly":true},"mounts":[],"linux":{"namespaces":[{"type":"pid"},{"type":"mount"}]}}' >"$BUNDLE/config.json"
+
+START=$(date +%s%N)
+set +e
+FIRST_ERROR=$(crun --root "$RUNTIME_ROOT" --cgroup-manager=disabled run --bundle "$BUNDLE" rauha-wasm-1 2>&1)
+FIRST_STATUS=$?
+set -e
+if [ "$FIRST_STATUS" -ne 0 ]; then
+    ELAPSED_US=$((($(date +%s%N) - START) / 1000))
+    printf 'crun=%s\navailable=false\nprobe_us=%s\nerror=%s\n' \
+        "$(crun --version | head -n 1)" "$ELAPSED_US" "$FIRST_ERROR"
+    exit 0
+fi
+for iteration in $(seq 2 "$ITERATIONS"); do
+    crun --root "$RUNTIME_ROOT" --cgroup-manager=disabled run --bundle "$BUNDLE" "rauha-wasm-$iteration"
+done
+END=$(date +%s%N)
+AVERAGE_US=$(((END - START) / ITERATIONS / 1000))
+
+printf 'crun=%s\navailable=true\niterations=%s\naverage_us=%s\n' \
+    "$(crun --version | head -n 1)" "$ITERATIONS" "$AVERAGE_US"

--- a/eval/wasm-tier-result.md
+++ b/eval/wasm-tier-result.md
@@ -1,0 +1,24 @@
+# Wasm isolation-tier probe
+
+Measured 2026-08-27 in the locked `syva-dev` Lima gate with
+`eval/wasm-tier-probe.sh`:
+
+```text
+crun=crun version 1.14.1
+available=false
+probe_us=2103
+error=could not load `libwasmedge.so.0`: `libwasmedge.so.0: cannot open shared object file: No such file or directory`
+```
+
+The probe used crun's experimental `run.oci.handler=wasm` path and a minimal
+41-byte WebAssembly `_start` module. The same gate measured Rauha's native OCI
+create/enroll/start handoff at 13 ms average (`n=5`). crun advertises
+`+WASM:wasmedge`, but the locked host cannot execute the module because its
+declared handler library is absent.
+
+Decision: do not expose a Wasm tier yet. First package and pin WasmEdge in the
+locked gate, then require the Wasm path to preserve Rauha policy admission and
+signed receipt semantics. Re-run this probe and promote the tier only if it
+works and materially improves on the native handoff. This follows crun's
+[experimental handler contract](https://github.com/containers/crun/blob/main/crun.1.md#runocihandlerhandler)
+without adding another runtime abstraction to Rauha.

--- a/policies/privileged.toml
+++ b/policies/privileged.toml
@@ -30,8 +30,8 @@ pids_max = 4096
 [network]
 mode = "host"
 allowed_zones = []
-allowed_egress = ["0.0.0.0/0:0"]
-allowed_ingress = ["0.0.0.0/0:0"]
+allowed_egress = []
+allowed_ingress = []
 
 [filesystem]
 shared_layers = true

--- a/proto/sandbox.proto
+++ b/proto/sandbox.proto
@@ -63,6 +63,10 @@ message SandboxResult {
     string admission = 13;
     // Isolation checks that were unavailable or failed at execution time.
     repeated string unavailable_controls = 14;
+    // Ed25519-signed rauha.execution-receipt.v1 JSON. The signature covers the
+    // manifest admission, effective policy, inputs, outputs, enforcement
+    // totals, observed drop count, and final outcome.
+    string receipt_json = 15;
 }
 
 message SandboxEventSummary {

--- a/rauha-cli/Cargo.toml
+++ b/rauha-cli/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 rauha-common = { path = "../rauha-common" }
+rauha-evidence = { path = "../rauha-evidence" }
 
 tokio = { workspace = true }
 tonic = { workspace = true }

--- a/rauha-cli/build.rs
+++ b/rauha-cli/build.rs
@@ -2,6 +2,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_server(false)
         .build_client(true)
+        .client_mod_attribute(
+            ".",
+            "#[allow(clippy::mixed_attributes_style, clippy::result_large_err)]",
+        )
         .compile_protos(
             &[
                 "../proto/zone.proto",

--- a/rauha-cli/src/commands/mod.rs
+++ b/rauha-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod image;
 pub mod logs;
 pub mod output;
 pub mod policy;
+pub mod receipt;
 pub mod run;
 pub mod sandbox;
 pub mod setup;

--- a/rauha-cli/src/commands/output.rs
+++ b/rauha-cli/src/commands/output.rs
@@ -208,6 +208,15 @@ pub struct SandboxRun {
     pub unavailable_controls: Vec<String>,
     pub events: Vec<SandboxEvent>,
     pub enforcement_events: Vec<SandboxEnforcementEvent>,
+    pub receipt: rauha_evidence::receipt::SignedExecutionReceipt,
+}
+
+#[derive(Serialize)]
+pub struct ReceiptVerification {
+    pub ok: bool,
+    pub schema: String,
+    pub task_id: String,
+    pub digest: String,
 }
 
 #[derive(Serialize)]

--- a/rauha-cli/src/commands/receipt.rs
+++ b/rauha-cli/src/commands/receipt.rs
@@ -1,0 +1,36 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use rauha_evidence::receipt::SignedExecutionReceipt;
+
+use super::output::{self, OutputMode};
+
+#[derive(Args)]
+pub struct ReceiptArgs {
+    /// Receipt JSON or `rauha sandbox --json` output containing a receipt.
+    pub file: PathBuf,
+    /// Trusted daemon Ed25519 public-key file.
+    #[arg(long)]
+    pub public_key: PathBuf,
+}
+
+pub fn verify(args: ReceiptArgs, out: OutputMode) -> anyhow::Result<()> {
+    let value: serde_json::Value = serde_json::from_slice(&std::fs::read(&args.file)?)?;
+    let receipt: SignedExecutionReceipt =
+        serde_json::from_value(value.get("receipt").cloned().unwrap_or(value))?;
+    let trusted_public_key = std::fs::read_to_string(&args.public_key)?;
+    receipt
+        .verify_trusted(&trusted_public_key)
+        .map_err(anyhow::Error::msg)?;
+    let digest = receipt.sha256();
+    let result = output::ReceiptVerification {
+        ok: true,
+        schema: receipt.payload.schema,
+        task_id: receipt.payload.task_id,
+        digest,
+    };
+    output::print(out, &result, || {
+        println!("verified: {} {}", result.task_id, result.digest)
+    });
+    Ok(())
+}

--- a/rauha-cli/src/commands/sandbox.rs
+++ b/rauha-cli/src/commands/sandbox.rs
@@ -92,6 +92,12 @@ pub async fn handle_sandbox(args: SandboxArgs, out: OutputMode) -> anyhow::Resul
         "timed_out" => 137,
         _ => 1,
     });
+    let receipt: rauha_evidence::receipt::SignedExecutionReceipt =
+        serde_json::from_str(&result.receipt_json)
+            .map_err(|error| anyhow::anyhow!("daemon returned an invalid receipt: {error}"))?;
+    receipt
+        .verify()
+        .map_err(|error| anyhow::anyhow!("daemon returned an unverifiable receipt: {error}"))?;
 
     let view = output::SandboxRun {
         ok: result.status == "succeeded",
@@ -128,6 +134,7 @@ pub async fn handle_sandbox(args: SandboxArgs, out: OutputMode) -> anyhow::Resul
                 object: e.object,
             })
             .collect(),
+        receipt,
     };
 
     output::print(out, &view, || {
@@ -146,12 +153,13 @@ pub async fn handle_sandbox(args: SandboxArgs, out: OutputMode) -> anyhow::Resul
             format!("  enforcement: {} event(s)", view.enforcement_events.len())
         };
         eprintln!(
-            "status: {}  exit: {}  admission: {}  ({:.1}s){}",
+            "status: {}  exit: {}  admission: {}  ({:.1}s){}  receipt: {}",
             view.status,
             code,
             view.admission,
             view.duration_ms as f64 / 1000.0,
             enforcement,
+            view.receipt.sha256(),
         );
         if !view.unavailable_controls.is_empty() {
             eprintln!(

--- a/rauha-cli/src/main.rs
+++ b/rauha-cli/src/main.rs
@@ -27,6 +27,8 @@ enum Commands {
     },
     /// Run an agent task in a sandbox zone, capturing output and events
     Sandbox(commands::sandbox::SandboxArgs),
+    /// Verify a signed execution receipt
+    Receipt(commands::receipt::ReceiptArgs),
     /// Run a container in a zone
     Run(commands::run::RunArgs),
     /// List containers
@@ -97,6 +99,7 @@ async fn main() {
     let result = match cli.command {
         Commands::Zone { action } => commands::zone::handle(action, out).await,
         Commands::Sandbox(args) => commands::sandbox::handle_sandbox(args, out).await,
+        Commands::Receipt(args) => commands::receipt::verify(args, out),
         Commands::Run(args) => commands::run::handle_run(args, out).await,
         Commands::Ps(args) => commands::run::handle_ps(args, out).await,
         Commands::Stop(args) => commands::run::handle_stop(args, out).await,

--- a/rauha-common/src/sandbox.rs
+++ b/rauha-common/src/sandbox.rs
@@ -23,6 +23,7 @@ pub struct SandboxExecResult {
     pub finished_at: Option<DateTime<Utc>>,
     pub events: Vec<SandboxEventSummary>,
     pub enforcement_events: Vec<EnforcementEventSummary>,
+    pub enforcement_drop_count: u64,
 }
 
 impl SandboxExecResult {
@@ -46,6 +47,7 @@ impl SandboxExecResult {
             finished_at: None,
             events: Vec::new(),
             enforcement_events: Vec::new(),
+            enforcement_drop_count: 0,
         }
     }
 }
@@ -111,6 +113,7 @@ mod tests {
             finished_at: None,
             events: Vec::new(),
             enforcement_events: Vec::new(),
+            enforcement_drop_count: 0,
         };
 
         let value = serde_json::to_value(&result).unwrap();

--- a/rauha-common/src/zone.rs
+++ b/rauha-common/src/zone.rs
@@ -2,6 +2,8 @@ use std::net::Ipv4Addr;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+use std::str::FromStr;
 use uuid::Uuid;
 
 /// Network state assigned to a zone at creation time.
@@ -121,6 +123,99 @@ pub struct NetworkPolicy {
     pub allowed_zones: Vec<String>,
     pub allowed_egress: Vec<String>,
     pub allowed_ingress: Vec<String>,
+}
+
+/// A validated network policy target: IP address/CIDR with an optional TCP port.
+///
+/// IPv4 ports use `address:port`; IPv6 ports require `[address]:port` so the
+/// policy grammar stays unambiguous. A target without a port allows all IP
+/// protocols to that network.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetworkEndpoint {
+    pub address: IpAddr,
+    pub prefix_len: u8,
+    pub port: Option<u16>,
+}
+
+impl NetworkEndpoint {
+    fn parse_network(value: &str) -> Result<(IpAddr, u8), String> {
+        let (address, prefix) = match value.split_once('/') {
+            Some((address, prefix)) => (address, Some(prefix)),
+            None => (value, None),
+        };
+        let address = address
+            .parse::<IpAddr>()
+            .map_err(|_| format!("invalid IP address or CIDR: {value}"))?;
+        let max_prefix = if address.is_ipv4() { 32 } else { 128 };
+        let prefix_len = prefix
+            .map(|prefix| {
+                prefix
+                    .parse::<u8>()
+                    .map_err(|_| format!("invalid CIDR prefix: {value}"))
+            })
+            .transpose()?
+            .unwrap_or(max_prefix);
+        if prefix_len > max_prefix {
+            return Err(format!("CIDR prefix exceeds {max_prefix}: {value}"));
+        }
+        Ok((address, prefix_len))
+    }
+
+    pub fn nft_family(self) -> &'static str {
+        if self.address.is_ipv4() {
+            "ip"
+        } else {
+            "ip6"
+        }
+    }
+
+    pub fn network(self) -> String {
+        format!("{}/{}", self.address, self.prefix_len)
+    }
+}
+
+impl FromStr for NetworkEndpoint {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let value = value.trim();
+        if value.is_empty() {
+            return Err("network target is empty".into());
+        }
+
+        let (network, port) = if let Some(rest) = value.strip_prefix('[') {
+            let (network, port) = rest
+                .split_once("]:")
+                .ok_or_else(|| format!("invalid bracketed network target: {value}"))?;
+            (network, Some(port))
+        } else if Self::parse_network(value).is_ok() {
+            (value, None)
+        } else {
+            let (network, port) = value
+                .rsplit_once(':')
+                .ok_or_else(|| format!("invalid network target: {value}"))?;
+            (network, Some(port))
+        };
+
+        let (address, prefix_len) = Self::parse_network(network)?;
+        let port = port
+            .map(|port| {
+                let port = port
+                    .parse::<u16>()
+                    .map_err(|_| format!("invalid TCP port: {value}"))?;
+                if port == 0 {
+                    return Err(format!("TCP port must be between 1 and 65535: {value}"));
+                }
+                Ok(port)
+            })
+            .transpose()?;
+
+        Ok(Self {
+            address,
+            prefix_len,
+            port,
+        })
+    }
 }
 
 impl Default for NetworkPolicy {
@@ -488,11 +583,20 @@ impl PolicyFile {
                         )))
                     }
                 };
+                let allowed_egress = n.allowed_egress.clone().unwrap_or_default();
+                let allowed_ingress = n.allowed_ingress.clone().unwrap_or_default();
+                for target in allowed_egress.iter().chain(&allowed_ingress) {
+                    target.parse::<NetworkEndpoint>().map_err(|error| {
+                        crate::error::RauhaError::InvalidPolicy(format!(
+                            "invalid network target {target:?}: {error}"
+                        ))
+                    })?;
+                }
                 Ok(NetworkPolicy {
                     mode,
                     allowed_zones: n.allowed_zones.clone().unwrap_or_default(),
-                    allowed_egress: n.allowed_egress.clone().unwrap_or_default(),
-                    allowed_ingress: n.allowed_ingress.clone().unwrap_or_default(),
+                    allowed_egress,
+                    allowed_ingress,
                 })
             })
             .transpose()?
@@ -589,6 +693,24 @@ mod tests {
         assert!(policy.capabilities.allowed.is_empty());
         assert_eq!(policy.resources.cpu_shares, 1024);
         assert_eq!(policy.network.mode, NetworkMode::Isolated);
+    }
+
+    #[test]
+    fn network_targets_validate_ipv4_ipv6_and_ports() {
+        let ipv4: NetworkEndpoint = "10.0.0.0/8:443".parse().unwrap();
+        assert_eq!(ipv4.nft_family(), "ip");
+        assert_eq!(ipv4.network(), "10.0.0.0/8");
+        assert_eq!(ipv4.port, Some(443));
+
+        let ipv6: NetworkEndpoint = "[2001:db8::/32]:8443".parse().unwrap();
+        assert_eq!(ipv6.nft_family(), "ip6");
+        assert_eq!(ipv6.network(), "2001:db8::/32");
+        assert_eq!(ipv6.port, Some(8443));
+
+        assert!("2001:db8::/32".parse::<NetworkEndpoint>().is_ok());
+        assert!("0.0.0.0/0:0".parse::<NetworkEndpoint>().is_err());
+        assert!("0.0.0.0/99".parse::<NetworkEndpoint>().is_err());
+        assert!("0.0.0.0/0 accept".parse::<NetworkEndpoint>().is_err());
     }
 
     fn policy_with_caps(caps: &[&str]) -> ZonePolicy {

--- a/rauha-evidence/Cargo.toml
+++ b/rauha-evidence/Cargo.toml
@@ -12,3 +12,10 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
+ed25519-dalek = { workspace = true }
+libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/rauha-evidence/src/lib.rs
+++ b/rauha-evidence/src/lib.rs
@@ -16,6 +16,8 @@ use chrono::{DateTime, SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+pub mod receipt;
+
 pub mod event_name {
     pub const DAEMON_START: &str = "rauha.daemon.start";
     pub const DAEMON_READY: &str = "rauha.daemon.ready";

--- a/rauha-evidence/src/receipt.rs
+++ b/rauha-evidence/src/receipt.rs
@@ -1,0 +1,276 @@
+use std::collections::BTreeMap;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::Path;
+
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const EXECUTION_RECEIPT_SCHEMA: &str = "rauha.execution-receipt.v1";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImageAdmission {
+    pub reference: String,
+    pub manifest_digest: String,
+    pub digest_verified: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnforcementTotals {
+    pub allow: u64,
+    pub deny: u64,
+    pub error: u64,
+    pub dropped: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionReceiptPayload {
+    pub schema: String,
+    pub task_id: String,
+    pub zone_id: String,
+    pub image: ImageAdmission,
+    pub policy_sha256: String,
+    pub inputs_sha256: String,
+    pub outputs_sha256: String,
+    pub status: String,
+    pub exit_code: Option<i32>,
+    pub started_at: Option<String>,
+    pub finished_at: Option<String>,
+    pub enforcement: EnforcementTotals,
+    pub unavailable_controls: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedExecutionReceipt {
+    pub payload: ExecutionReceiptPayload,
+    pub public_key: String,
+    pub signature: String,
+}
+
+#[derive(Clone)]
+pub struct ReceiptSigner(SigningKey);
+
+impl ReceiptSigner {
+    pub fn load_or_create(path: &Path) -> Result<Self, String> {
+        match read_key(path) {
+            Ok(key) => return Ok(Self(SigningKey::from_bytes(&key))),
+            Err(error) if error.kind() != std::io::ErrorKind::NotFound => {
+                return Err(format!("failed to read receipt signing key: {error}"));
+            }
+            Err(_) => {}
+        }
+
+        let parent = path
+            .parent()
+            .ok_or_else(|| "receipt signing key path has no parent".to_string())?;
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create receipt key directory: {error}"))?;
+        let mut key = [0u8; 32];
+        File::open("/dev/urandom")
+            .and_then(|mut random| random.read_exact(&mut key))
+            .map_err(|error| format!("failed to generate receipt signing key: {error}"))?;
+
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(path)
+        {
+            Ok(mut file) => {
+                file.write_all(&key)
+                    .and_then(|_| file.sync_all())
+                    .map_err(|error| format!("failed to persist receipt signing key: {error}"))?;
+                Ok(Self(SigningKey::from_bytes(&key)))
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => read_key(path)
+                .map(|key| Self(SigningKey::from_bytes(&key)))
+                .map_err(|error| format!("failed to read concurrent receipt key: {error}")),
+            Err(error) => Err(format!("failed to create receipt signing key: {error}")),
+        }
+    }
+
+    pub fn sign(&self, payload: ExecutionReceiptPayload) -> SignedExecutionReceipt {
+        let bytes = serde_json::to_vec(&payload).expect("receipt payload is serializable");
+        SignedExecutionReceipt {
+            signature: hex::encode(self.0.sign(&bytes).to_bytes()),
+            public_key: hex::encode(self.0.verifying_key().to_bytes()),
+            payload,
+        }
+    }
+
+    pub fn publish_public_key(&self, path: &Path) -> Result<(), String> {
+        let expected = format!("{}\n", hex::encode(self.0.verifying_key().to_bytes()));
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o644)
+            .open(path)
+        {
+            Ok(mut file) => file
+                .write_all(expected.as_bytes())
+                .and_then(|_| file.sync_all())
+                .map_err(|error| format!("failed to publish receipt public key: {error}")),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let actual = read_public_key(path)
+                    .map_err(|error| format!("failed to read receipt public key: {error}"))?;
+                if actual == expected.trim() {
+                    Ok(())
+                } else {
+                    Err("receipt public key does not match the signing key".into())
+                }
+            }
+            Err(error) => Err(format!("failed to publish receipt public key: {error}")),
+        }
+    }
+}
+
+impl SignedExecutionReceipt {
+    pub fn verify(&self) -> Result<(), String> {
+        if self.payload.schema != EXECUTION_RECEIPT_SCHEMA {
+            return Err(format!(
+                "unsupported receipt schema: {}",
+                self.payload.schema
+            ));
+        }
+        let public_key: [u8; 32] = hex::decode(&self.public_key)
+            .map_err(|_| "receipt public key is not hexadecimal".to_string())?
+            .try_into()
+            .map_err(|_| "receipt public key must be 32 bytes".to_string())?;
+        let signature = Signature::from_slice(
+            &hex::decode(&self.signature)
+                .map_err(|_| "receipt signature is not hexadecimal".to_string())?,
+        )
+        .map_err(|_| "receipt signature must be 64 bytes".to_string())?;
+        let bytes = serde_json::to_vec(&self.payload)
+            .map_err(|error| format!("failed to serialize receipt payload: {error}"))?;
+        VerifyingKey::from_bytes(&public_key)
+            .map_err(|_| "receipt public key is invalid".to_string())?
+            .verify_strict(&bytes, &signature)
+            .map_err(|_| "receipt signature verification failed".to_string())
+    }
+
+    pub fn verify_trusted(&self, trusted_public_key: &str) -> Result<(), String> {
+        if self.public_key != trusted_public_key.trim() {
+            return Err("receipt signer does not match the trusted public key".into());
+        }
+        self.verify()
+    }
+
+    pub fn sha256(&self) -> String {
+        sha256_bytes(&serde_json::to_vec(self).expect("receipt is serializable"))
+    }
+}
+
+pub fn sha256_json<T: Serialize>(value: &T) -> Result<String, serde_json::Error> {
+    serde_json::to_vec(value).map(|bytes| sha256_bytes(&bytes))
+}
+
+pub fn enforcement_totals<I>(decisions: I, dropped: u64) -> EnforcementTotals
+where
+    I: IntoIterator,
+    I::Item: AsRef<str>,
+{
+    let mut counts = BTreeMap::new();
+    for decision in decisions {
+        *counts.entry(decision.as_ref().to_string()).or_insert(0u64) += 1;
+    }
+    EnforcementTotals {
+        allow: counts.remove("allow").unwrap_or_default(),
+        deny: counts.remove("deny").unwrap_or_default(),
+        error: counts.remove("error").unwrap_or_default(),
+        dropped,
+    }
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    format!("sha256:{}", hex::encode(Sha256::digest(bytes)))
+}
+
+fn read_key(path: &Path) -> std::io::Result<[u8; 32]> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    if file.metadata()?.mode() & 0o077 != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "receipt signing key must not be accessible by group or others",
+        ));
+    }
+    let mut key = [0u8; 32];
+    file.read_exact(&mut key)?;
+    let mut extra = [0u8; 1];
+    if file.read(&mut extra)? != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "receipt signing key must be exactly 32 bytes",
+        ));
+    }
+    Ok(key)
+}
+
+fn read_public_key(path: &Path) -> std::io::Result<String> {
+    let mut value = String::new();
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?
+        .read_to_string(&mut value)?;
+    Ok(value.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload() -> ExecutionReceiptPayload {
+        ExecutionReceiptPayload {
+            schema: EXECUTION_RECEIPT_SCHEMA.into(),
+            task_id: "task-1".into(),
+            zone_id: "zone-1".into(),
+            image: ImageAdmission {
+                reference: "example/image@sha256:abc".into(),
+                manifest_digest: "sha256:abc".into(),
+                digest_verified: true,
+            },
+            policy_sha256: "sha256:policy".into(),
+            inputs_sha256: "sha256:inputs".into(),
+            outputs_sha256: "sha256:outputs".into(),
+            status: "succeeded".into(),
+            exit_code: Some(0),
+            started_at: None,
+            finished_at: None,
+            enforcement: EnforcementTotals::default(),
+            unavailable_controls: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn signed_receipt_detects_payload_tampering() {
+        let dir = tempfile::tempdir().unwrap();
+        let signer = ReceiptSigner::load_or_create(&dir.path().join("receipt.key")).unwrap();
+        signer
+            .publish_public_key(&dir.path().join("receipt.pub"))
+            .unwrap();
+        let mut receipt = signer.sign(payload());
+        let trusted = std::fs::read_to_string(dir.path().join("receipt.pub")).unwrap();
+        receipt.verify_trusted(&trusted).unwrap();
+        receipt.payload.status = "failed".into();
+        assert!(receipt.verify().is_err());
+    }
+
+    #[test]
+    fn enforcement_totals_include_observed_drops() {
+        assert_eq!(
+            enforcement_totals(["allow", "deny", "deny", "error"], 3),
+            EnforcementTotals {
+                allow: 1,
+                deny: 2,
+                error: 1,
+                dropped: 3,
+            }
+        );
+    }
+}

--- a/rauha-oci/src/distribution.rs
+++ b/rauha-oci/src/distribution.rs
@@ -99,9 +99,10 @@ impl DistributionClient {
         &self,
         reference: &ImageReference,
     ) -> Result<OciManifest, RauhaError> {
+        let selector = reference.digest.as_deref().unwrap_or(&reference.tag);
         let url = format!(
             "https://{}/v2/{}/manifests/{}",
-            reference.registry, reference.repository, reference.tag
+            reference.registry, reference.repository, selector
         );
 
         let accept = &[
@@ -116,6 +117,7 @@ impl DistributionClient {
             .await?;
 
         let canonical = reference.to_string_canonical();
+        verify_manifest_digest(reference.digest.as_deref(), &body, &canonical)?;
 
         // Try parsing as a single manifest first.
         if let Ok(manifest) = serde_json::from_slice::<OciManifest>(&body) {
@@ -176,6 +178,7 @@ impl DistributionClient {
                 ],
             )
             .await?;
+        verify_manifest_digest(Some(&platform_entry.digest), &manifest_body, &canonical)?;
 
         self.content
             .put_manifest(&canonical, &manifest_body)
@@ -264,16 +267,14 @@ impl DistributionClient {
         // Try with cached token first.
         if let Some(token) = self.get_cached_token(registry, &scope).await {
             let resp = self
-                .http
-                .get(url)
-                .header("Accept", accept.join(", "))
-                .bearer_auth(&token)
-                .send()
-                .await
-                .map_err(|e| RauhaError::ImagePullError {
-                    reference: url.to_string(),
-                    message: format!("request failed: {e}"),
-                })?;
+                .send_with_rate_limit(
+                    self.http
+                        .get(url)
+                        .header("Accept", accept.join(", "))
+                        .bearer_auth(&token),
+                    url,
+                )
+                .await?;
 
             if resp.status().is_success() {
                 return resp.bytes().await.map(|b| b.to_vec()).map_err(|e| {
@@ -287,15 +288,8 @@ impl DistributionClient {
 
         // Initial request (may get 401).
         let resp = self
-            .http
-            .get(url)
-            .header("Accept", accept.join(", "))
-            .send()
-            .await
-            .map_err(|e| RauhaError::ImagePullError {
-                reference: url.to_string(),
-                message: format!("request failed: {e}"),
-            })?;
+            .send_with_rate_limit(self.http.get(url).header("Accept", accept.join(", ")), url)
+            .await?;
 
         if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
             let www_auth = resp
@@ -310,16 +304,14 @@ impl DistributionClient {
 
             // Retry with token.
             let resp = self
-                .http
-                .get(url)
-                .header("Accept", accept.join(", "))
-                .bearer_auth(&token)
-                .send()
-                .await
-                .map_err(|e| RauhaError::ImagePullError {
-                    reference: url.to_string(),
-                    message: format!("retry request failed: {e}"),
-                })?;
+                .send_with_rate_limit(
+                    self.http
+                        .get(url)
+                        .header("Accept", accept.join(", "))
+                        .bearer_auth(&token),
+                    url,
+                )
+                .await?;
 
             if !resp.status().is_success() {
                 return Err(RauhaError::ImagePullError {
@@ -363,15 +355,8 @@ impl DistributionClient {
         // Try with cached token.
         if let Some(token) = self.get_cached_token(registry, &scope).await {
             let resp = self
-                .http
-                .get(url)
-                .bearer_auth(&token)
-                .send()
-                .await
-                .map_err(|e| RauhaError::ImagePullError {
-                    reference: url.to_string(),
-                    message: format!("request failed: {e}"),
-                })?;
+                .send_with_rate_limit(self.http.get(url).bearer_auth(&token), url)
+                .await?;
 
             if resp.status().is_success() {
                 return Ok(resp);
@@ -379,15 +364,7 @@ impl DistributionClient {
         }
 
         // Initial request.
-        let resp = self
-            .http
-            .get(url)
-            .send()
-            .await
-            .map_err(|e| RauhaError::ImagePullError {
-                reference: url.to_string(),
-                message: format!("request failed: {e}"),
-            })?;
+        let resp = self.send_with_rate_limit(self.http.get(url), url).await?;
 
         if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
             let www_auth = resp
@@ -401,15 +378,8 @@ impl DistributionClient {
             self.cache_token(registry, &scope, &token).await;
 
             let resp = self
-                .http
-                .get(url)
-                .bearer_auth(&token)
-                .send()
-                .await
-                .map_err(|e| RauhaError::ImagePullError {
-                    reference: url.to_string(),
-                    message: format!("retry failed: {e}"),
-                })?;
+                .send_with_rate_limit(self.http.get(url).bearer_auth(&token), url)
+                .await?;
 
             if !resp.status().is_success() {
                 return Err(RauhaError::ImagePullError {
@@ -444,14 +414,8 @@ impl DistributionClient {
         let url = format!("{realm}?service={service}&scope={scope}");
 
         let resp: serde_json::Value = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .map_err(|e| RauhaError::ImagePullError {
-                reference: url.clone(),
-                message: format!("token request failed: {e}"),
-            })?
+            .send_with_rate_limit(self.http.get(&url), &url)
+            .await?
             .json()
             .await
             .map_err(|e| RauhaError::ImagePullError {
@@ -483,6 +447,51 @@ impl DistributionClient {
             .lock()
             .await
             .insert((registry.to_string(), scope.to_string()), token.to_string());
+    }
+
+    async fn send_with_rate_limit(
+        &self,
+        request: reqwest::RequestBuilder,
+        reference: &str,
+    ) -> Result<reqwest::Response, RauhaError> {
+        for attempt in 0..4 {
+            let response = request
+                .try_clone()
+                .expect("OCI GET requests are cloneable")
+                .send()
+                .await
+                .map_err(|error| RauhaError::ImagePullError {
+                    reference: reference.into(),
+                    message: format!("request failed: {error}"),
+                })?;
+            if response.status() != reqwest::StatusCode::TOO_MANY_REQUESTS || attempt == 3 {
+                return Ok(response);
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(1 << attempt)).await;
+        }
+        unreachable!()
+    }
+}
+
+fn verify_manifest_digest(
+    expected: Option<&str>,
+    body: &[u8],
+    reference: &str,
+) -> Result<(), RauhaError> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    let digest = Digest::parse(expected).ok_or_else(|| RauhaError::ImagePullError {
+        reference: reference.into(),
+        message: format!("invalid manifest digest: {expected}"),
+    })?;
+    if digest.validate(body) {
+        Ok(())
+    } else {
+        Err(RauhaError::ImagePullError {
+            reference: reference.into(),
+            message: format!("manifest digest mismatch for {digest}"),
+        })
     }
 }
 
@@ -561,6 +570,19 @@ mod tests {
             Some("https://ghcr.io/token")
         );
         assert_eq!(extract_param(header, "service"), Some("ghcr.io"));
+    }
+
+    #[test]
+    fn manifest_digest_mismatch_is_rejected() {
+        let body = b"manifest";
+        let digest = Digest::from_data(body);
+        verify_manifest_digest(Some(digest.as_str()), body, "image").unwrap();
+        assert!(verify_manifest_digest(
+            Some("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            body,
+            "image",
+        )
+        .is_err());
     }
 
     #[test]

--- a/rauha-oci/src/image.rs
+++ b/rauha-oci/src/image.rs
@@ -72,6 +72,33 @@ impl ImageService {
                 reference: reference_str.into(),
                 message: e,
             })?;
+        let canonical = reference.to_string_canonical();
+        if let Some(bytes) =
+            self.content
+                .get_manifest(&canonical)
+                .map_err(|error| RauhaError::ContentError {
+                    message: format!("failed to read cached manifest: {error}"),
+                })?
+        {
+            if let Ok(manifest) = serde_json::from_slice::<OciManifest>(&bytes) {
+                let complete = std::iter::once(&manifest.config)
+                    .chain(manifest.layers.iter())
+                    .all(|entry| {
+                        Digest::parse(&entry.digest)
+                            .is_some_and(|digest| self.content.has_blob(&digest))
+                    });
+                if complete {
+                    on_progress(PullProgress {
+                        status: "pull complete (cached)".into(),
+                        layer: String::new(),
+                        current: 0,
+                        total: 0,
+                        done: true,
+                    });
+                    return Ok(manifest);
+                }
+            }
+        }
 
         on_progress(PullProgress {
             status: "pulling manifest".into(),
@@ -766,6 +793,24 @@ pub(crate) mod tests {
         let inner = config.config.unwrap();
         assert_eq!(inner.cmd.unwrap(), vec!["/bin/sh"]);
         assert_eq!(inner.env.unwrap(), vec!["PATH=/usr/bin"]);
+    }
+
+    #[tokio::test]
+    async fn pull_reuses_a_complete_cached_image() {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, _) = setup_content_store_with_image(dir.path());
+        let svc = ImageService::new(store, dir.path().to_path_buf());
+        let mut statuses = Vec::new();
+
+        let manifest = svc
+            .pull("testimage:latest", |progress| {
+                statuses.push(progress.status)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(manifest.layers.len(), 1);
+        assert_eq!(statuses, ["pull complete (cached)"]);
     }
 
     #[test]

--- a/rauha-oci/src/image.rs
+++ b/rauha-oci/src/image.rs
@@ -57,6 +57,14 @@ impl ImageService {
         }
     }
 
+    fn manifest_blobs_present(&self, manifest: &OciManifest) -> bool {
+        std::iter::once(&manifest.config)
+            .chain(manifest.layers.iter())
+            .all(|entry| {
+                Digest::parse(&entry.digest).is_some_and(|digest| self.content.has_blob(&digest))
+            })
+    }
+
     /// Pull an image from a registry, storing blobs in the content store.
     /// Returns progress events via the callback.
     pub async fn pull<F>(
@@ -73,30 +81,28 @@ impl ImageService {
                 message: e,
             })?;
         let canonical = reference.to_string_canonical();
-        if let Some(bytes) =
-            self.content
-                .get_manifest(&canonical)
-                .map_err(|error| RauhaError::ContentError {
-                    message: format!("failed to read cached manifest: {error}"),
-                })?
-        {
-            if let Ok(manifest) = serde_json::from_slice::<OciManifest>(&bytes) {
-                let complete = std::iter::once(&manifest.config)
-                    .chain(manifest.layers.iter())
-                    .all(|entry| {
-                        Digest::parse(&entry.digest)
-                            .is_some_and(|digest| self.content.has_blob(&digest))
-                    });
-                if complete {
-                    on_progress(PullProgress {
-                        status: "pull complete (cached)".into(),
-                        layer: String::new(),
-                        current: 0,
-                        total: 0,
-                        done: true,
-                    });
-                    return Ok(manifest);
-                }
+        let cached = self
+            .content
+            .get_manifest(&canonical)
+            .map_err(|error| RauhaError::ContentError {
+                message: format!("failed to read cached manifest: {error}"),
+            })?
+            .and_then(|bytes| serde_json::from_slice::<OciManifest>(&bytes).ok())
+            .filter(|manifest| self.manifest_blobs_present(manifest));
+
+        // A digest reference is immutable, so a complete cache is final. A tag
+        // can move, so it is re-resolved against the registry; the cache only
+        // stands in when the registry cannot be reached.
+        if reference.digest.is_some() {
+            if let Some(manifest) = cached {
+                on_progress(PullProgress {
+                    status: "pull complete (cached)".into(),
+                    layer: String::new(),
+                    current: 0,
+                    total: 0,
+                    done: true,
+                });
+                return Ok(manifest);
             }
         }
 
@@ -108,7 +114,23 @@ impl ImageService {
             done: false,
         });
 
-        let manifest = self.client.pull_manifest(&reference).await?;
+        let manifest = match self.client.pull_manifest(&reference).await {
+            Ok(manifest) => manifest,
+            Err(error) => {
+                let Some(manifest) = cached else {
+                    return Err(error);
+                };
+                tracing::warn!(reference = %canonical, %error, "registry unreachable; using cached tag");
+                on_progress(PullProgress {
+                    status: "pull complete (cached; registry unreachable)".into(),
+                    layer: String::new(),
+                    current: 0,
+                    total: 0,
+                    done: true,
+                });
+                return Ok(manifest);
+            }
+        };
 
         // Pull config blob.
         let config_digest =
@@ -690,8 +712,15 @@ pub fn unpack_layer(
                 continue;
             }
             if let Some(original) = name.strip_prefix(".wh.") {
-                if original.is_empty() {
-                    return Err(invalid_layer_path(&path, "whiteout target is empty"));
+                // The derived target must be exactly one plain name: `.wh...`
+                // would otherwise resolve to `..` and delete the staging
+                // directory's parent on the host.
+                if original.is_empty()
+                    || original == "."
+                    || original == ".."
+                    || original.contains('/')
+                {
+                    return Err(invalid_layer_path(&path, "invalid whiteout target"));
                 }
                 // File whiteout: delete the corresponding file.
                 if let Some(parent) = path.parent() {
@@ -795,22 +824,67 @@ pub(crate) mod tests {
         assert_eq!(inner.env.unwrap(), vec!["PATH=/usr/bin"]);
     }
 
+    /// Re-key the fixture manifest under a reference whose registry is a
+    /// closed local port, so a pull that consults the registry fails fast
+    /// instead of reaching the network.
+    fn store_manifest_under(store: &ContentStore, reference: &str) -> String {
+        let bytes = store
+            .get_manifest("registry-1.docker.io/library/testimage:latest")
+            .unwrap()
+            .unwrap();
+        let canonical = ImageReference::parse(reference)
+            .unwrap()
+            .to_string_canonical();
+        store.put_manifest(&canonical, &bytes).unwrap();
+        reference.to_string()
+    }
+
     #[tokio::test]
-    async fn pull_reuses_a_complete_cached_image() {
+    async fn pull_by_digest_is_served_from_a_complete_cache() {
         let dir = tempfile::tempdir().unwrap();
         let (store, _) = setup_content_store_with_image(dir.path());
+        let manifest_bytes = store
+            .get_manifest("registry-1.docker.io/library/testimage:latest")
+            .unwrap()
+            .unwrap();
+        let digest = store.put_blob(&manifest_bytes).unwrap();
+        let reference = store_manifest_under(
+            &store,
+            &format!("127.0.0.1:1/testimage@{}", digest.as_str()),
+        );
         let svc = ImageService::new(store, dir.path().to_path_buf());
         let mut statuses = Vec::new();
 
         let manifest = svc
-            .pull("testimage:latest", |progress| {
-                statuses.push(progress.status)
-            })
+            .pull(&reference, |progress| statuses.push(progress.status))
             .await
             .unwrap();
 
         assert_eq!(manifest.layers.len(), 1);
         assert_eq!(statuses, ["pull complete (cached)"]);
+    }
+
+    #[tokio::test]
+    async fn pull_by_tag_consults_the_registry_and_falls_back_to_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, _) = setup_content_store_with_image(dir.path());
+        let reference = store_manifest_under(&store, "127.0.0.1:1/testimage:latest");
+        let svc = ImageService::new(store, dir.path().to_path_buf());
+        let mut statuses = Vec::new();
+
+        let manifest = svc
+            .pull(&reference, |progress| statuses.push(progress.status))
+            .await
+            .unwrap();
+
+        assert_eq!(manifest.layers.len(), 1);
+        assert_eq!(
+            statuses,
+            [
+                "pulling manifest",
+                "pull complete (cached; registry unreachable)"
+            ]
+        );
     }
 
     #[test]
@@ -1000,6 +1074,33 @@ pub(crate) mod tests {
 
         // The file should have been deleted by the whiteout.
         assert!(!rootfs.join("etc/config.txt").exists());
+    }
+
+    #[test]
+    fn whiteout_target_cannot_name_the_parent_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("rootfs");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(dir.path().join("sibling"), b"host data").unwrap();
+
+        for name in [".wh...", ".wh.."] {
+            let layer = make_tar_gz(&[(name, b"")]);
+            let layer_path = dir.path().join("layer.tar.gz");
+            std::fs::write(&layer_path, layer).unwrap();
+            let decoder = flate2::read::GzDecoder::new(std::fs::File::open(&layer_path).unwrap());
+            let mut archive = tar::Archive::new(decoder);
+
+            let error = unpack_layer(&mut archive, &target).unwrap_err();
+            assert!(
+                error.to_string().contains("invalid whiteout target"),
+                "{name}"
+            );
+        }
+        assert!(target.is_dir());
+        assert_eq!(
+            std::fs::read(dir.path().join("sibling")).unwrap(),
+            b"host data"
+        );
     }
 
     #[test]

--- a/rauha-oci/src/image.rs
+++ b/rauha-oci/src/image.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use rauha_common::error::RauhaError;
@@ -529,6 +529,111 @@ impl ImageService {
     }
 }
 
+fn invalid_layer_path(path: &Path, reason: &str) -> RauhaError {
+    RauhaError::RootfsError {
+        message: format!("unsafe layer path {}: {reason}", path.display()),
+    }
+}
+
+fn clean_layer_path(path: &Path) -> Result<PathBuf, RauhaError> {
+    let mut clean = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => clean.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(invalid_layer_path(path, "path escapes the rootfs"));
+            }
+        }
+    }
+    if clean.as_os_str().is_empty() {
+        return Err(invalid_layer_path(path, "path is empty"));
+    }
+    Ok(clean)
+}
+
+/// Resolve an existing whiteout parent without following image-controlled symlinks.
+///
+/// Layer extraction happens in a private staging directory, so rejecting every
+/// symlink component closes the whiteout escape without another path library.
+fn whiteout_parent(target: &Path, relative: &Path) -> Result<Option<PathBuf>, RauhaError> {
+    let mut current = target.canonicalize().map_err(|e| RauhaError::RootfsError {
+        message: format!("failed to resolve rootfs {}: {e}", target.display()),
+    })?;
+
+    for component in relative.components() {
+        let Component::Normal(part) = component else {
+            return Err(invalid_layer_path(relative, "invalid whiteout parent"));
+        };
+        current.push(part);
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(invalid_layer_path(relative, "whiteout parent is a symlink"));
+            }
+            Ok(metadata) if !metadata.is_dir() => {
+                return Err(invalid_layer_path(
+                    relative,
+                    "whiteout parent is not a directory",
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(RauhaError::RootfsError {
+                    message: format!(
+                        "failed to inspect whiteout parent {}: {error}",
+                        current.display()
+                    ),
+                });
+            }
+        }
+    }
+
+    Ok(Some(current))
+}
+
+fn remove_path(path: &Path) -> Result<(), RauhaError> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(RauhaError::RootfsError {
+                message: format!(
+                    "failed to inspect whiteout target {}: {error}",
+                    path.display()
+                ),
+            });
+        }
+    };
+
+    let result = if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    };
+    result.map_err(|e| RauhaError::RootfsError {
+        message: format!("failed to apply whiteout to {}: {e}", path.display()),
+    })
+}
+
+fn clear_directory(path: &Path) -> Result<(), RauhaError> {
+    for entry in std::fs::read_dir(path).map_err(|e| RauhaError::RootfsError {
+        message: format!(
+            "failed to read opaque whiteout directory {}: {e}",
+            path.display()
+        ),
+    })? {
+        remove_path(
+            &entry
+                .map_err(|e| RauhaError::RootfsError {
+                    message: format!("failed to read opaque whiteout entry: {e}"),
+                })?
+                .path(),
+        )?;
+    }
+    Ok(())
+}
+
 /// Unpack a tar layer into a target directory, handling OCI whiteout files.
 pub fn unpack_layer(
     archive: &mut tar::Archive<flate2::read::GzDecoder<std::fs::File>>,
@@ -544,39 +649,31 @@ pub fn unpack_layer(
         let path = entry.path().map_err(|e| RauhaError::RootfsError {
             message: format!("invalid tar entry path: {e}"),
         })?;
-        let path = path.to_path_buf();
+        let path = clean_layer_path(&path)?;
 
         // Check for OCI whiteout markers.
         if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
             if name == ".wh..wh..opq" {
                 // Opaque whiteout: remove all existing contents of the parent directory.
                 if let Some(parent) = path.parent() {
-                    let full_parent = target.join(parent);
-                    if full_parent.exists() {
-                        let _ = std::fs::remove_dir_all(&full_parent);
-                        let _ = std::fs::create_dir_all(&full_parent);
+                    if let Some(full_parent) = whiteout_parent(target, parent)? {
+                        clear_directory(&full_parent)?;
                     }
                 }
                 continue;
             }
             if let Some(original) = name.strip_prefix(".wh.") {
+                if original.is_empty() {
+                    return Err(invalid_layer_path(&path, "whiteout target is empty"));
+                }
                 // File whiteout: delete the corresponding file.
                 if let Some(parent) = path.parent() {
-                    let to_delete = target.join(parent).join(original);
-                    if to_delete.is_dir() {
-                        let _ = std::fs::remove_dir_all(&to_delete);
-                    } else {
-                        let _ = std::fs::remove_file(&to_delete);
+                    if let Some(full_parent) = whiteout_parent(target, parent)? {
+                        remove_path(&full_parent.join(original))?;
                     }
                 }
                 continue;
             }
-        }
-
-        // Validate path: prevent path traversal.
-        let full_path = target.join(&path);
-        if !full_path.starts_with(target) {
-            continue;
         }
 
         entry
@@ -858,6 +955,36 @@ pub(crate) mod tests {
 
         // The file should have been deleted by the whiteout.
         assert!(!rootfs.join("etc/config.txt").exists());
+    }
+
+    #[test]
+    fn whiteout_rejects_parent_traversal() {
+        let error = clean_layer_path(Path::new("../outside/.wh.victim")).unwrap_err();
+        assert!(error.to_string().contains("path escapes the rootfs"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn whiteout_does_not_follow_a_symlinked_parent() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("rootfs");
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("victim"), b"host data").unwrap();
+        symlink(&outside, target.join("escape")).unwrap();
+
+        let layer = make_tar_gz(&[("escape/.wh.victim", b"")]);
+        let layer_path = dir.path().join("layer.tar.gz");
+        std::fs::write(&layer_path, layer).unwrap();
+        let decoder = flate2::read::GzDecoder::new(std::fs::File::open(layer_path).unwrap());
+        let mut archive = tar::Archive::new(decoder);
+
+        let error = unpack_layer(&mut archive, &target).unwrap_err();
+        assert!(error.to_string().contains("whiteout parent is a symlink"));
+        assert_eq!(std::fs::read(outside.join("victim")).unwrap(), b"host data");
     }
 
     #[test]

--- a/rauha-oci/src/snapshotter.rs
+++ b/rauha-oci/src/snapshotter.rs
@@ -183,7 +183,7 @@ impl OverlayfsSnapshotter {
         work: &Path,
         merged: &Path,
     ) -> Result<()> {
-        use nix::mount::{mount, MsFlags};
+        use nix::mount::{mount, umount2, MntFlags, MsFlags};
 
         if layer_paths.is_empty() {
             return Err(RauhaError::RootfsError {
@@ -224,6 +224,18 @@ impl OverlayfsSnapshotter {
                 "overlayfs mount failed: {e} — try: modprobe overlay; or check that /proc/filesystems contains overlay"
             ),
         })?;
+        if let Err(error) = mount(
+            None::<&str>,
+            merged,
+            None::<&str>,
+            MsFlags::MS_PRIVATE,
+            None::<&str>,
+        ) {
+            let _ = umount2(merged, MntFlags::MNT_DETACH);
+            return Err(RauhaError::RootfsError {
+                message: format!("failed to make overlay rootfs private: {error}"),
+            });
+        }
 
         Ok(())
     }

--- a/rauha-shim/src/attach.rs
+++ b/rauha-shim/src/attach.rs
@@ -361,6 +361,13 @@ pub fn fork_and_exec_pty(
     let c_env = cstring_vec(env, "exec.env")?;
     let term = CString::new("TERM=xterm-256color")?;
     let spec: oci_spec::runtime::Spec = serde_json::from_str(spec_json)?;
+    if spec
+        .linux()
+        .as_ref()
+        .is_some_and(|linux| linux.seccomp().is_some())
+    {
+        anyhow::bail!("interactive exec is disabled for seccomp-filtered containers");
+    }
     let process = spec
         .process()
         .as_ref()

--- a/rauha-shim/src/container.rs
+++ b/rauha-shim/src/container.rs
@@ -75,16 +75,37 @@ impl RuntimeProcess {
         None
     }
 
-    pub fn stop_and_delete(&mut self) {
-        if self.try_wait().is_none() {
-            let _ = self.signal(9);
+    /// Wait up to `grace` for init to exit, then SIGKILL it and wait again.
+    ///
+    /// Init is PID 1 of its own pid namespace, where a signal with default
+    /// disposition (SIGTERM to `sleep`, say) is silently discarded — so a
+    /// delivered stop signal proves nothing until the pidfd reports exit.
+    pub fn wait_or_kill(&mut self, grace: Duration) -> i32 {
+        if let Some(exit_code) = self.wait_until(Instant::now() + grace) {
+            return exit_code;
         }
+        let _ = self.signal(9);
+        let exit_code = self
+            .wait_until(Instant::now() + Duration::from_secs(5))
+            .unwrap_or(128 + 9);
+        self.delete();
+        exit_code
+    }
 
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while self.try_wait().is_none() && Instant::now() < deadline {
+    fn wait_until(&mut self, deadline: Instant) -> Option<i32> {
+        loop {
+            if let Some(exit_code) = self.try_wait() {
+                return Some(exit_code);
+            }
+            if Instant::now() >= deadline {
+                return None;
+            }
             std::thread::sleep(Duration::from_millis(10));
         }
-        self.delete();
+    }
+
+    pub fn stop_and_delete(&mut self) {
+        self.wait_or_kill(Duration::ZERO);
     }
 
     fn delete(&mut self) {

--- a/rauha-shim/src/container.rs
+++ b/rauha-shim/src/container.rs
@@ -1,16 +1,21 @@
 #[cfg(any(target_os = "linux", test))]
 use std::ffi::OsString;
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 #[cfg(target_os = "linux")]
 use std::process::Stdio;
-use std::process::{Child, Command};
 use std::time::{Duration, Instant};
 
 const CRUN: &str = "/usr/bin/crun";
 
-/// A foreground crun process supervised by the zone shim.
+/// An OCI init process supervised by the zone shim.
 pub struct RuntimeProcess {
-    child: Child,
+    #[cfg(target_os = "linux")]
+    pidfd: OwnedFd,
+    #[cfg(target_os = "linux")]
+    pid: libc::pid_t,
     runtime_root: PathBuf,
     id: String,
     cleaned: bool,
@@ -18,43 +23,68 @@ pub struct RuntimeProcess {
 
 impl RuntimeProcess {
     pub fn signal(&self, signal: i32) -> anyhow::Result<()> {
-        let output = runtime_command(&self.runtime_root)
-            .arg("kill")
-            .arg(&self.id)
-            .arg(signal.to_string())
-            .output()?;
-        if output.status.success() {
-            Ok(())
-        } else {
-            anyhow::bail!(
-                "crun kill failed for {}: {}",
-                self.id,
-                String::from_utf8_lossy(&output.stderr).trim()
-            )
+        #[cfg(target_os = "linux")]
+        {
+            let rc = unsafe {
+                libc::syscall(
+                    libc::SYS_pidfd_send_signal,
+                    self.pidfd.as_raw_fd(),
+                    signal,
+                    std::ptr::null::<libc::siginfo_t>(),
+                    0,
+                )
+            };
+            if rc == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error().into())
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = signal;
+            anyhow::bail!("pidfd signaling is only supported on Linux")
         }
     }
 
-    /// Return the workload exit code once crun exits and clean its runtime state.
+    /// Return the workload exit code once init exits and clean its runtime state.
     pub fn try_wait(&mut self) -> Option<i32> {
-        let status = self.child.try_wait().ok()??;
-        self.delete();
-        Some(status.code().unwrap_or(125))
+        #[cfg(target_os = "linux")]
+        {
+            let mut pollfd = libc::pollfd {
+                fd: self.pidfd.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            if unsafe { libc::poll(&mut pollfd, 1, 0) } <= 0 {
+                return None;
+            }
+            let mut status = 0;
+            let waited = unsafe { libc::waitpid(self.pid, &mut status, libc::WNOHANG) };
+            let exit_code = if waited == self.pid && libc::WIFEXITED(status) {
+                libc::WEXITSTATUS(status)
+            } else if waited == self.pid && libc::WIFSIGNALED(status) {
+                128 + libc::WTERMSIG(status)
+            } else {
+                125
+            };
+            self.delete();
+            Some(exit_code)
+        }
+        #[cfg(not(target_os = "linux"))]
+        None
     }
 
     pub fn stop_and_delete(&mut self) {
-        if self.child.try_wait().ok().flatten().is_none() {
+        if self.try_wait().is_none() {
             let _ = self.signal(9);
         }
-        self.delete();
 
         let deadline = Instant::now() + Duration::from_secs(5);
-        while self.child.try_wait().ok().flatten().is_none() && Instant::now() < deadline {
+        while self.try_wait().is_none() && Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(10));
         }
-        if self.child.try_wait().ok().flatten().is_none() {
-            let _ = self.child.kill();
-            let _ = self.child.wait();
-        }
+        self.delete();
     }
 
     fn delete(&mut self) {
@@ -70,13 +100,14 @@ impl RuntimeProcess {
 
 /// Start an OCI bundle with crun while the shim remains its foreground supervisor.
 pub fn start_with_crun(
+    zone_name: &str,
     container_id: &str,
     spec_json: &str,
     rootfs_root: &Path,
 ) -> anyhow::Result<(RuntimeProcess, u32)> {
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (container_id, spec_json, rootfs_root);
+        let _ = (zone_name, container_id, spec_json, rootfs_root);
         anyhow::bail!("crun execution is only supported on Linux")
     }
 
@@ -84,6 +115,9 @@ pub fn start_with_crun(
     {
         if !Path::new(CRUN).is_file() {
             anyhow::bail!("required OCI runtime is missing: {CRUN}");
+        }
+        if unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) } != 0 {
+            return Err(std::io::Error::last_os_error().into());
         }
 
         let bundle = rootfs_root.join("containers").join(container_id);
@@ -100,49 +134,85 @@ pub fn start_with_crun(
         let log_dir = PathBuf::from("/run/rauha/containers").join(container_id);
         std::fs::create_dir_all(&log_dir)?;
 
-        let mut command = runtime_command(&runtime_root);
-        command
-            .args(crun_run_args(&bundle, &pid_file, container_id))
+        let status = runtime_command(&runtime_root)
+            .args(crun_create_args(&bundle, &pid_file, container_id))
             .stdin(Stdio::null())
             .stdout(Stdio::from(std::fs::File::create(
                 log_dir.join("stdout.log"),
             )?))
             .stderr(Stdio::from(std::fs::File::create(
                 log_dir.join("stderr.log"),
-            )?));
-        let mut child = command.spawn()?;
-
-        let deadline = Instant::now() + Duration::from_secs(30);
-        loop {
-            if let Ok(pid) = std::fs::read_to_string(&pid_file)
-                .and_then(|pid| pid.trim().parse::<u32>().map_err(std::io::Error::other))
-            {
-                return Ok((
-                    RuntimeProcess {
-                        child,
-                        runtime_root,
-                        id: container_id.to_string(),
-                        cleaned: false,
-                    },
-                    pid,
-                ));
-            }
-            if let Some(status) = child.try_wait()? {
-                let _ = runtime_command(&runtime_root)
-                    .args(["delete", "--force", container_id])
-                    .status();
-                anyhow::bail!("crun exited before publishing the init PID: {status}");
-            }
-            if Instant::now() >= deadline {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = runtime_command(&runtime_root)
-                    .args(["delete", "--force", container_id])
-                    .status();
-                anyhow::bail!("crun did not publish the init PID within 30 seconds");
-            }
-            std::thread::sleep(Duration::from_millis(10));
+            )?))
+            .status()?;
+        if !status.success() {
+            let error = std::fs::read_to_string(log_dir.join("stderr.log")).unwrap_or_default();
+            let _ = runtime_command(&runtime_root)
+                .args(["delete", "--force", container_id])
+                .status();
+            anyhow::bail!("crun create failed: {}", error.trim());
         }
+
+        let pid = match std::fs::read_to_string(&pid_file)
+            .and_then(|pid| pid.trim().parse::<u32>().map_err(std::io::Error::other))
+        {
+            Ok(pid) => pid,
+            Err(error) => {
+                let _ = runtime_command(&runtime_root)
+                    .args(["delete", "--force", container_id])
+                    .status();
+                return Err(error.into());
+            }
+        };
+        let pidfd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
+        if pidfd < 0 {
+            let error = std::io::Error::last_os_error();
+            let _ = runtime_command(&runtime_root)
+                .args(["delete", "--force", container_id])
+                .status();
+            return Err(error.into());
+        }
+        let pidfd = unsafe { OwnedFd::from_raw_fd(pidfd as i32) };
+
+        let cgroup = format!("/sys/fs/cgroup/rauha.slice/zone-{zone_name}/cgroup.procs");
+        if let Err(error) = std::fs::write(&cgroup, pid.to_string()) {
+            let _ = runtime_command(&runtime_root)
+                .args(["delete", "--force", container_id])
+                .status();
+            anyhow::bail!("failed to enroll OCI init in {cgroup}: {error}");
+        }
+
+        let output = match runtime_command(&runtime_root)
+            .args(["start", container_id])
+            .output()
+        {
+            Ok(output) => output,
+            Err(error) => {
+                let _ = runtime_command(&runtime_root)
+                    .args(["delete", "--force", container_id])
+                    .status();
+                return Err(error.into());
+            }
+        };
+        if !output.status.success() {
+            let _ = runtime_command(&runtime_root)
+                .args(["delete", "--force", container_id])
+                .status();
+            anyhow::bail!(
+                "crun start failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+
+        Ok((
+            RuntimeProcess {
+                pidfd,
+                pid: pid as libc::pid_t,
+                runtime_root,
+                id: container_id.to_string(),
+                cleaned: false,
+            },
+            pid,
+        ))
     }
 }
 
@@ -156,9 +226,9 @@ fn runtime_command(runtime_root: &Path) -> Command {
 }
 
 #[cfg(any(target_os = "linux", test))]
-fn crun_run_args(bundle: &Path, pid_file: &Path, container_id: &str) -> Vec<OsString> {
+fn crun_create_args(bundle: &Path, pid_file: &Path, container_id: &str) -> Vec<OsString> {
     vec![
-        "run".into(),
+        "create".into(),
         "--bundle".into(),
         bundle.as_os_str().into(),
         "--pid-file".into(),
@@ -340,16 +410,16 @@ pub(crate) fn clone_process(flags: u64) -> nix::Result<nix::unistd::ForkResult> 
 
 #[cfg(test)]
 mod tests {
-    use super::crun_run_args;
+    use super::crun_create_args;
     use std::path::Path;
 
     #[test]
-    fn crun_runs_the_bundle_in_the_foreground_with_a_pid_file() {
+    fn crun_creates_the_bundle_with_a_pid_file_before_start() {
         assert_eq!(
-            crun_run_args(Path::new("/bundle"), Path::new("/bundle/init.pid"), "c1"),
+            crun_create_args(Path::new("/bundle"), Path::new("/bundle/init.pid"), "c1"),
             Vec::<std::ffi::OsString>::from(
                 [
-                    "run",
+                    "create",
                     "--bundle",
                     "/bundle",
                     "--pid-file",

--- a/rauha-shim/src/container.rs
+++ b/rauha-shim/src/container.rs
@@ -1,374 +1,170 @@
-use std::path::Path;
-
-/// Fork a child process, set up rootfs, and run the container workload.
-///
-/// Flow (two-phase handshake):
-/// 1. Create two sync pipes (setup: child->parent, go: parent->child)
-/// 2. fork()
-/// 3. Child: privileged setup (unshare/mount/pivot_root) -> signal "setup done"
-///    -> block on "go" -> execvp the workload
-/// 4. Parent: wait for "setup done" -> enroll child PID in zone cgroup
-///    -> signal "go" -> return PID
-///
-/// The privileged bootstrap runs *before* cgroup enrollment, so the eBPF
-/// `capable` hook does not judge rauha's own CAP_SYS_ADMIN setup against the
-/// workload's policy. The untrusted workload (`execvp`) is started only after
-/// enrollment is confirmed, so the TOCTOU enforcement boundary still holds:
-/// no image code ever runs outside the zone. Enrollment failure is fatal —
-/// the workload is never started unenforced (fail closed).
-///
-/// Note: This uses execvp (not shell exec) - no shell injection possible.
-/// The child process image is replaced entirely by the container command.
+#[cfg(any(target_os = "linux", test))]
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 #[cfg(target_os = "linux")]
-pub fn fork_and_exec(
-    zone_name: &str,
+use std::process::Stdio;
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+const CRUN: &str = "/usr/bin/crun";
+
+/// A foreground crun process supervised by the zone shim.
+pub struct RuntimeProcess {
+    child: Child,
+    runtime_root: PathBuf,
+    id: String,
+    cleaned: bool,
+}
+
+impl RuntimeProcess {
+    pub fn signal(&self, signal: i32) -> anyhow::Result<()> {
+        let output = runtime_command(&self.runtime_root)
+            .arg("kill")
+            .arg(&self.id)
+            .arg(signal.to_string())
+            .output()?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            anyhow::bail!(
+                "crun kill failed for {}: {}",
+                self.id,
+                String::from_utf8_lossy(&output.stderr).trim()
+            )
+        }
+    }
+
+    /// Return the workload exit code once crun exits and clean its runtime state.
+    pub fn try_wait(&mut self) -> Option<i32> {
+        let status = self.child.try_wait().ok()??;
+        self.delete();
+        Some(status.code().unwrap_or(125))
+    }
+
+    pub fn stop_and_delete(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.signal(9);
+        }
+        self.delete();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while self.child.try_wait().ok().flatten().is_none() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+
+    fn delete(&mut self) {
+        if self.cleaned {
+            return;
+        }
+        let _ = runtime_command(&self.runtime_root)
+            .args(["delete", "--force", &self.id])
+            .status();
+        self.cleaned = true;
+    }
+}
+
+/// Start an OCI bundle with crun while the shim remains its foreground supervisor.
+pub fn start_with_crun(
     container_id: &str,
     spec_json: &str,
     rootfs_root: &Path,
-) -> anyhow::Result<u32> {
-    use nix::unistd::ForkResult;
-    use oci_spec::runtime::Spec;
-    use std::ffi::CString;
-    use std::os::fd::{AsRawFd, BorrowedFd};
-    use std::os::unix::ffi::OsStrExt;
-    use std::path::PathBuf;
-
-    let spec: Spec = serde_json::from_str(spec_json)?;
-    let readonly_root = spec
-        .root()
-        .as_ref()
-        .and_then(|root| root.readonly())
-        .unwrap_or(false);
-
-    let process = spec
-        .process()
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("spec missing process"))?;
-    let args = process
-        .args()
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("spec missing process.args"))?;
-    if args.is_empty() {
-        anyhow::bail!("process.args is empty");
+) -> anyhow::Result<(RuntimeProcess, u32)> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (container_id, spec_json, rootfs_root);
+        anyhow::bail!("crun execution is only supported on Linux")
     }
 
-    // Check both overlayfs (merged/) and legacy (rootfs/) paths.
-    let container_dir = rootfs_root.join("containers").join(container_id);
-    let rootfs = {
-        let merged = container_dir.join("merged");
-        let legacy = container_dir.join("rootfs");
-        if merged.exists() {
-            merged
-        } else if legacy.exists() {
-            legacy
-        } else {
-            anyhow::bail!(
-                "rootfs not found: checked {} and {}",
-                merged.display(),
-                legacy.display()
-            );
+    #[cfg(target_os = "linux")]
+    {
+        if !Path::new(CRUN).is_file() {
+            anyhow::bail!("required OCI runtime is missing: {CRUN}");
         }
-    };
 
-    // Set up stdio log directory.
-    let log_dir = PathBuf::from("/run/rauha/containers").join(container_id);
-    std::fs::create_dir_all(&log_dir)?;
-
-    // Two sync pipes for the two-phase handshake. OwnedFd closes on drop.
-    //   setup pipe: child -> parent ("privileged setup done, safe to enroll")
-    //   go pipe:    parent -> child ("enrolled, proceed to exec the workload")
-    let (setup_rd, setup_wr) = nix::unistd::pipe()?;
-    let (go_rd, go_wr) = nix::unistd::pipe()?;
-
-    // Prepare C strings before fork (allocation not async-signal-safe after fork).
-    let c_args = cstring_vec(args, "process.args")?;
-
-    let env_vars = process
-        .env()
-        .as_ref()
-        .map(|vars| cstring_vec(vars, "process.env"))
-        .transpose()?
-        .unwrap_or_default();
-
-    let cwd = process.cwd().to_string_lossy().to_string();
-    let cwd_cstr = CString::new(cwd.as_str())?;
-
-    let hostname = spec.hostname().clone();
-    let mut unshare_flags = nix::sched::CloneFlags::CLONE_NEWNS;
-    let mut netns = None;
-    let mut new_pid_namespace = false;
-    if let Some(linux) = spec.linux().as_ref() {
-        if let Some(namespaces) = linux.namespaces().as_ref() {
-            for namespace in namespaces {
-                match namespace.typ() {
-                    oci_spec::runtime::LinuxNamespaceType::Uts => {
-                        unshare_flags |= nix::sched::CloneFlags::CLONE_NEWUTS;
-                    }
-                    oci_spec::runtime::LinuxNamespaceType::Ipc => {
-                        unshare_flags |= nix::sched::CloneFlags::CLONE_NEWIPC;
-                    }
-                    oci_spec::runtime::LinuxNamespaceType::Network => {
-                        let path = namespace.path().as_ref().ok_or_else(|| {
-                            anyhow::anyhow!("network namespace requires an existing path")
-                        })?;
-                        netns = Some(std::fs::File::open(path)?);
-                    }
-                    oci_spec::runtime::LinuxNamespaceType::Pid => {
-                        new_pid_namespace = true;
-                    }
-                    _ => {}
-                }
-            }
+        let bundle = rootfs_root.join("containers").join(container_id);
+        if !bundle.join("merged").is_dir() && !bundle.join("rootfs").is_dir() {
+            anyhow::bail!("rootfs not found for container {container_id}");
         }
-    }
-    if hostname.is_some() && !unshare_flags.contains(nix::sched::CloneFlags::CLONE_NEWUTS) {
-        anyhow::bail!("hostname requires a private UTS namespace");
-    }
-    let process_security = ProcessSecurity::from_process(process)?;
-    let cap_last_cap = std::fs::read_to_string("/proc/sys/kernel/cap_last_cap")?
-        .trim()
-        .parse::<u32>()?
-        .min(63);
 
-    // Pre-allocate log file paths as CStrings for signal-safe use after fork.
-    let stdout_log =
-        std::ffi::CString::new(log_dir.join("stdout.log").to_string_lossy().as_bytes())
-            .unwrap_or_default();
-    let stderr_log =
-        std::ffi::CString::new(log_dir.join("stderr.log").to_string_lossy().as_bytes())
-            .unwrap_or_default();
+        let runtime_root = rootfs_root.join("runtime");
+        std::fs::create_dir_all(&runtime_root)?;
+        std::fs::write(bundle.join("config.json"), spec_json)?;
 
-    // Pre-allocate pivot_root paths as CStrings BEFORE fork — the child path
-    // must not allocate (fork-safety invariant).
-    let rootfs_cstr = CString::new(rootfs.as_os_str().as_bytes()).unwrap_or_default();
-    let pivot_old_cstr =
-        CString::new(rootfs.join(".pivot_old").as_os_str().as_bytes()).unwrap_or_default();
+        let pid_file = bundle.join("init.pid");
+        let _ = std::fs::remove_file(&pid_file);
+        let log_dir = PathBuf::from("/run/rauha/containers").join(container_id);
+        std::fs::create_dir_all(&log_dir)?;
 
-    // Convert OwnedFds to raw fds for use across fork.
-    // We manage lifetime manually after fork (each side closes the ends it
-    // does not use, by dropping the corresponding OwnedFd).
-    let setup_rd_raw = setup_rd.as_raw_fd();
-    let setup_wr_raw = setup_wr.as_raw_fd();
-    let go_rd_raw = go_rd.as_raw_fd();
-    let go_wr_raw = go_wr.as_raw_fd();
+        let mut command = runtime_command(&runtime_root);
+        command
+            .args(crun_run_args(&bundle, &pid_file, container_id))
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(std::fs::File::create(
+                log_dir.join("stdout.log"),
+            )?))
+            .stderr(Stdio::from(std::fs::File::create(
+                log_dir.join("stderr.log"),
+            )?));
+        let mut child = command.spawn()?;
 
-    // clone3 creates the workload bootstrap directly as PID 1 when requested;
-    // unshare(CLONE_NEWPID) would affect only later children and leave the
-    // workload itself in the host PID namespace.
-    let clone_flags = if new_pid_namespace {
-        libc::CLONE_NEWPID as u64
-    } else {
-        0
-    };
-    match clone_process(clone_flags)? {
-        ForkResult::Child => {
-            // Close the pipe ends this process does not use.
-            drop(setup_rd);
-            drop(go_wr);
-
-            // New session.
-            let _ = nix::unistd::setsid();
-
-            // Redirect stdout/stderr to log files. Must happen before pivot_root
-            // while /run/rauha/... is still reachable on the host filesystem.
-            // Uses raw open() with pre-allocated CStrings — async-signal-safe.
-            redirect_stdio_raw(&stdout_log, &stderr_log);
-
-            // --- Privileged container bootstrap, BEFORE cgroup enrollment ---
-            // The child is not yet a zone member here, so the eBPF `capable`
-            // hook sees no zone (lookup_caller_zone -> None -> allow) and does
-            // not judge these CAP_SYS_ADMIN operations against the workload's
-            // policy. No image code runs in this window — only this fixed,
-            // trusted setup sequence, after which we block until enrolled.
-
-            // Enter a new mount namespace and make all mounts private.
-            // pivot_root requires: (1) own mount namespace, (2) private root mount.
-            // Without MS_PRIVATE|MS_REC, inherited shared mounts cause EINVAL.
-            // Error reporting in the child must be async-signal-safe: static
-            // byte messages + libc::write, never format!/alloc. The specific
-            // errno is dropped; the failing operation is still identifiable.
-            if let Some(netns) = netns.as_ref() {
-                if nix::sched::setns(netns, nix::sched::CloneFlags::CLONE_NEWNET).is_err() {
-                    unsafe {
-                        let msg = b"rauha-shim: setns(CLONE_NEWNET) failed\n";
-                        let _ = libc::write(2, msg.as_ptr() as _, msg.len());
-                        libc::_exit(1);
-                    }
-                }
-            }
-            drop(netns);
-
-            if nix::sched::unshare(unshare_flags).is_err() {
-                unsafe {
-                    let msg = b"rauha-shim: namespace unshare failed\n";
-                    let _ = libc::write(2, msg.as_ptr() as _, msg.len());
-                    libc::_exit(1);
-                }
-            }
-            // Make all mounts private — required for pivot_root to work.
-            if nix::mount::mount(
-                None::<&str>,
-                "/",
-                None::<&str>,
-                nix::mount::MsFlags::MS_PRIVATE | nix::mount::MsFlags::MS_REC,
-                None::<&str>,
-            )
-            .is_err()
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            if let Ok(pid) = std::fs::read_to_string(&pid_file)
+                .and_then(|pid| pid.trim().parse::<u32>().map_err(std::io::Error::other))
             {
-                unsafe {
-                    let msg = b"rauha-shim: mount(MS_PRIVATE) failed\n";
-                    let _ = libc::write(2, msg.as_ptr() as _, msg.len());
-                    libc::_exit(1);
-                }
+                return Ok((
+                    RuntimeProcess {
+                        child,
+                        runtime_root,
+                        id: container_id.to_string(),
+                        cleaned: false,
+                    },
+                    pid,
+                ));
             }
-
-            // pivot_root into the container rootfs.
-            if let Err(msg) = do_pivot_root(&rootfs_cstr, &pivot_old_cstr) {
-                unsafe {
-                    let _ = libc::write(2, msg.as_ptr() as _, msg.len());
-                    libc::_exit(1);
-                }
+            if let Some(status) = child.try_wait()? {
+                let _ = runtime_command(&runtime_root)
+                    .args(["delete", "--force", container_id])
+                    .status();
+                anyhow::bail!("crun exited before publishing the init PID: {status}");
             }
-
-            unsafe {
-                libc::mkdir(c"/proc".as_ptr(), 0o555);
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = runtime_command(&runtime_root)
+                    .args(["delete", "--force", container_id])
+                    .status();
+                anyhow::bail!("crun did not publish the init PID within 30 seconds");
             }
-            if nix::mount::mount(
-                Some("proc"),
-                "/proc",
-                Some("proc"),
-                nix::mount::MsFlags::MS_NOSUID
-                    | nix::mount::MsFlags::MS_NODEV
-                    | nix::mount::MsFlags::MS_NOEXEC,
-                None::<&str>,
-            )
-            .is_err()
-            {
-                unsafe {
-                    let msg = b"rauha-shim: procfs mount failed\n";
-                    let _ = libc::write(2, msg.as_ptr() as _, msg.len());
-                    libc::_exit(1);
-                }
-            }
-
-            if readonly_root
-                && nix::mount::mount(
-                    None::<&str>,
-                    "/",
-                    None::<&str>,
-                    nix::mount::MsFlags::MS_BIND
-                        | nix::mount::MsFlags::MS_REMOUNT
-                        | nix::mount::MsFlags::MS_RDONLY,
-                    None::<&str>,
-                )
-                .is_err()
-            {
-                unsafe {
-                    let msg = b"rauha-shim: read-only rootfs remount failed\n";
-                    let _ = libc::write(2, msg.as_ptr() as _, msg.len());
-                    libc::_exit(1);
-                }
-            }
-
-            // Set hostname.
-            if let Some(ref h) = hostname {
-                let _ = nix::unistd::sethostname(h);
-            }
-
-            // Drop privilege while still outside the zone cgroup. This is the
-            // final trusted bootstrap step; after enrollment the BPF capable()
-            // allow-list applies and must not be needed to remove privileges.
-            if apply_process_security(process_security, cap_last_cap).is_err() {
-                unsafe {
-                    let msg = b"rauha-shim: failed to apply process security\n";
-                    let _ = libc::write(2, msg.as_ptr() as _, msg.len());
-                    libc::_exit(1);
-                }
-            }
-
-            // Signal the parent that privileged setup is complete and it is
-            // safe to enroll us in the zone cgroup.
-            let _ = nix::unistd::write(unsafe { BorrowedFd::borrow_raw(setup_wr_raw) }, &[1u8]);
-            drop(setup_wr);
-
-            // Block until the parent confirms cgroup enrollment. From here on
-            // the process is inside the enforcement boundary, so the workload
-            // exec below is fully subject to zone policy.
-            let mut buf = [0u8; 1];
-            let n = nix::unistd::read(go_rd_raw, &mut buf);
-            drop(go_rd);
-            // The "go" pipe closing without a byte means the parent could not
-            // enroll us — refuse to run the workload unenforced (fail closed).
-            if !matches!(n, Ok(1)) {
-                let msg = b"cgroup enrollment failed; refusing to start workload unenforced\n";
-                unsafe {
-                    let _ = libc::write(2, msg.as_ptr() as _, msg.len());
-                    libc::_exit(125);
-                }
-            }
-
-            if new_pid_namespace {
-                supervise_workload(&c_args, &env_vars, cwd_cstr.as_c_str());
-            } else {
-                exec_workload(&c_args, &env_vars, cwd_cstr.as_c_str());
-            }
-        }
-        ForkResult::Parent { child } => {
-            // Close the pipe ends this process does not use.
-            drop(setup_wr);
-            drop(go_rd);
-
-            let child_pid = child.as_raw() as u32;
-            let child_p = nix::unistd::Pid::from_raw(child_pid as i32);
-
-            // Wait for the child to finish privileged setup before enrolling it,
-            // so its CAP_SYS_ADMIN bootstrap is not judged against zone policy.
-            // A read of 1 byte means setup succeeded; EOF (0) means the child
-            // died during setup (it already wrote its own error to stderr).
-            let mut buf = [0u8; 1];
-            let setup_ok = matches!(nix::unistd::read(setup_rd_raw, &mut buf), Ok(1));
-            drop(setup_rd);
-            if !setup_ok {
-                drop(go_wr);
-                let _ = nix::sys::wait::waitpid(child_p, None);
-                anyhow::bail!(
-                    "container {container_id} failed during pre-enrollment setup \
-                     (see container stderr)"
-                );
-            }
-
-            // Enroll child in zone cgroup. This MUST succeed: a workload running
-            // outside the cgroup gets no eBPF enforcement. On failure, kill the
-            // child and report the error rather than signaling "go" — fail closed.
-            let cgroup_path = format!("/sys/fs/cgroup/rauha.slice/zone-{zone_name}/cgroup.procs");
-            if let Err(e) = std::fs::write(&cgroup_path, child_pid.to_string()) {
-                let _ = nix::sys::signal::kill(child_p, nix::sys::signal::Signal::SIGKILL);
-                let _ = nix::sys::wait::waitpid(child_p, None);
-                drop(go_wr);
-                anyhow::bail!(
-                    "failed to enroll container {container_id} in zone cgroup \
-                     {cgroup_path}: {e}; refusing to start workload unenforced"
-                );
-            }
-
-            // Signal the child to proceed to exec — it is now inside the boundary.
-            let signaled = nix::unistd::write(unsafe { BorrowedFd::borrow_raw(go_wr_raw) }, &[1u8]);
-            drop(go_wr);
-            // A failed/short write (e.g. EPIPE) means the child went away between
-            // "setup done" and "go" — it will never exec the workload. Reap it
-            // and report failure rather than claiming a container started.
-            if !matches!(signaled, Ok(1)) {
-                let _ = nix::sys::wait::waitpid(child_p, None);
-                anyhow::bail!(
-                    "container {container_id} exited before workload exec \
-                     (enrollment signal not delivered)"
-                );
-            }
-
-            tracing::info!(pid = child_pid, container = container_id, "child forked");
-            Ok(child_pid)
+            std::thread::sleep(Duration::from_millis(10));
         }
     }
+}
+
+fn runtime_command(runtime_root: &Path) -> Command {
+    let mut command = Command::new(CRUN);
+    command
+        .arg("--root")
+        .arg(runtime_root)
+        .arg("--cgroup-manager=disabled");
+    command
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn crun_run_args(bundle: &Path, pid_file: &Path, container_id: &str) -> Vec<OsString> {
+    vec![
+        "run".into(),
+        "--bundle".into(),
+        bundle.as_os_str().into(),
+        "--pid-file".into(),
+        pid_file.as_os_str().into(),
+        container_id.into(),
+    ]
 }
 
 #[cfg(target_os = "linux")]
@@ -442,7 +238,7 @@ pub(crate) fn apply_process_security(
     }
 
     let header = UserCapHeader {
-        version: 0x2008_0522, // _LINUX_CAPABILITY_VERSION_3
+        version: 0x2008_0522,
         pid: 0,
     };
     let data = [
@@ -500,11 +296,7 @@ pub(crate) fn apply_process_security(
     Ok(())
 }
 
-/// fork(2)-equivalent clone3 with optional namespace flags.
-///
-/// clone3 uses the caller's copied stack when CLONE_VM is absent, so no child
-/// stack allocation is required. Rauha's supported Linux kernels already need
-/// clone3-era features for the security backend.
+/// fork(2)-equivalent clone3 used only by interactive exec.
 #[cfg(target_os = "linux")]
 pub(crate) fn clone_process(flags: u64) -> nix::Result<nix::unistd::ForkResult> {
     #[repr(C)]
@@ -546,149 +338,35 @@ pub(crate) fn clone_process(flags: u64) -> nix::Result<nix::unistd::ForkResult> 
     }
 }
 
-#[cfg(target_os = "linux")]
-fn exec_workload(args: &[std::ffi::CString], env: &[std::ffi::CString], cwd: &std::ffi::CStr) -> ! {
-    unsafe {
-        libc::clearenv();
-        for var in env {
-            libc::putenv(var.as_ptr() as *mut libc::c_char);
-        }
-    }
-    let _ = nix::unistd::chdir(cwd);
-    let _ = nix::unistd::execvp(&args[0], args);
-    unsafe {
-        let msg = b"rauha-shim: execvp failed\n";
-        let _ = libc::write(2, msg.as_ptr() as _, msg.len());
-        libc::_exit(127);
-    }
-}
-
-#[cfg(target_os = "linux")]
-static INIT_CHILD_PID: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(0);
-
-#[cfg(target_os = "linux")]
-extern "C" fn forward_init_signal(signal: libc::c_int) {
-    let child = INIT_CHILD_PID.load(std::sync::atomic::Ordering::Relaxed);
-    if child > 0 {
-        unsafe {
-            libc::kill(child, signal);
-        }
-    }
-}
-
-/// Minimal PID 1: forward lifecycle signals and reap the actual workload.
-#[cfg(target_os = "linux")]
-fn supervise_workload(
-    args: &[std::ffi::CString],
-    env: &[std::ffi::CString],
-    cwd: &std::ffi::CStr,
-) -> ! {
-    const FORWARDED_SIGNALS: &[libc::c_int] = &[
-        libc::SIGHUP,
-        libc::SIGINT,
-        libc::SIGQUIT,
-        libc::SIGTERM,
-        libc::SIGUSR1,
-        libc::SIGUSR2,
-        libc::SIGWINCH,
-        libc::SIGCONT,
-        libc::SIGTSTP,
-        libc::SIGTTIN,
-        libc::SIGTTOU,
-    ];
-
-    let mut blocked = unsafe { std::mem::zeroed::<libc::sigset_t>() };
-    let mut previous = unsafe { std::mem::zeroed::<libc::sigset_t>() };
-    unsafe {
-        libc::sigemptyset(&mut blocked);
-        for &signal in FORWARDED_SIGNALS {
-            libc::sigaddset(&mut blocked, signal);
-            let mut action = std::mem::zeroed::<libc::sigaction>();
-            action.sa_sigaction = forward_init_signal as *const () as usize;
-            libc::sigemptyset(&mut action.sa_mask);
-            libc::sigaction(signal, &action, std::ptr::null_mut());
-        }
-        libc::sigprocmask(libc::SIG_BLOCK, &blocked, &mut previous);
-    }
-
-    match clone_process(0) {
-        Ok(nix::unistd::ForkResult::Child) => {
-            unsafe {
-                libc::sigprocmask(libc::SIG_SETMASK, &previous, std::ptr::null_mut());
-            }
-            exec_workload(args, env, cwd);
-        }
-        Ok(nix::unistd::ForkResult::Parent { child }) => unsafe {
-            INIT_CHILD_PID.store(child.as_raw(), std::sync::atomic::Ordering::Relaxed);
-            libc::sigprocmask(libc::SIG_SETMASK, &previous, std::ptr::null_mut());
-            let mut main_exit = None;
-            loop {
-                let mut status = 0;
-                let waited = libc::waitpid(-1, &mut status, 0);
-                if waited > 0 {
-                    if waited == child.as_raw() {
-                        main_exit = wait_status_exit_code(status);
-                        // Container lifetime follows its main workload. Stop
-                        // descendants, then reap them before PID 1 exits.
-                        libc::kill(-1, libc::SIGKILL);
-                    }
-                    continue;
-                }
-                if waited < 0 {
-                    match nix::errno::Errno::last() {
-                        nix::errno::Errno::EINTR => continue,
-                        nix::errno::Errno::ECHILD => libc::_exit(main_exit.unwrap_or(125)),
-                        _ => libc::_exit(125),
-                    }
-                }
-            }
-        },
-        Err(_) => unsafe {
-            let msg = b"rauha-shim: PID 1 failed to start workload\n";
-            let _ = libc::write(2, msg.as_ptr() as _, msg.len());
-            libc::_exit(125);
-        },
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn wait_status_exit_code(status: libc::c_int) -> Option<libc::c_int> {
-    if libc::WIFEXITED(status) {
-        Some(libc::WEXITSTATUS(status))
-    } else if libc::WIFSIGNALED(status) {
-        Some(128 + libc::WTERMSIG(status))
-    } else {
-        None
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn cstring_vec(values: &[String], field: &str) -> anyhow::Result<Vec<std::ffi::CString>> {
-    values
-        .iter()
-        .enumerate()
-        .map(|(idx, value)| {
-            std::ffi::CString::new(value.as_str())
-                .map_err(|_| anyhow::anyhow!("{field}[{idx}] contains an interior NUL byte"))
-        })
-        .collect()
-}
-
-#[cfg(all(test, target_os = "linux"))]
+#[cfg(test)]
 mod tests {
-    use super::{cstring_vec, wait_status_exit_code, ProcessSecurity};
-    use oci_spec::runtime::{Capabilities, LinuxCapabilitiesBuilder, ProcessBuilder};
+    use super::crun_run_args;
+    use std::path::Path;
 
     #[test]
-    fn rejects_interior_nul_in_process_args() {
-        let err = cstring_vec(&["/bin/sh\0bad".to_string()], "process.args")
-            .expect_err("interior NUL must be rejected");
-
-        assert!(err.to_string().contains("process.args[0]"));
+    fn crun_runs_the_bundle_in_the_foreground_with_a_pid_file() {
+        assert_eq!(
+            crun_run_args(Path::new("/bundle"), Path::new("/bundle/init.pid"), "c1"),
+            Vec::<std::ffi::OsString>::from(
+                [
+                    "run",
+                    "--bundle",
+                    "/bundle",
+                    "--pid-file",
+                    "/bundle/init.pid",
+                    "c1"
+                ]
+                .map(std::ffi::OsString::from)
+            )
+        );
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn empty_oci_capabilities_mean_zero_process_capabilities() {
+        use super::ProcessSecurity;
+        use oci_spec::runtime::{Capabilities, LinuxCapabilitiesBuilder, ProcessBuilder};
+
         let capabilities = LinuxCapabilitiesBuilder::default()
             .bounding(Capabilities::default())
             .effective(Capabilities::default())
@@ -710,138 +388,5 @@ mod tests {
                 ..Default::default()
             }
         );
-    }
-
-    #[test]
-    fn wait_status_preserves_main_exit_code() {
-        assert_eq!(wait_status_exit_code(7 << 8), Some(7));
-        assert_eq!(
-            wait_status_exit_code(libc::SIGTERM),
-            Some(128 + libc::SIGTERM)
-        );
-    }
-}
-
-/// Non-Linux stub.
-#[cfg(not(target_os = "linux"))]
-pub fn fork_and_exec(
-    _zone_name: &str,
-    _container_id: &str,
-    _spec_json: &str,
-    _rootfs_root: &Path,
-) -> anyhow::Result<u32> {
-    anyhow::bail!("fork_and_exec is only supported on Linux")
-}
-
-/// Send a signal to a process.
-pub fn send_signal(pid: u32, signal: i32) -> anyhow::Result<()> {
-    #[cfg(target_os = "linux")]
-    {
-        use nix::sys::signal::{self, Signal};
-        use nix::unistd::Pid;
-
-        let sig = Signal::try_from(signal)?;
-        signal::kill(Pid::from_raw(pid as i32), sig)?;
-        Ok(())
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = (pid, signal);
-        anyhow::bail!("signal not supported on this platform")
-    }
-}
-
-/// Try to reap a child process (non-blocking). Returns exit code if exited.
-pub fn try_wait(pid: u32) -> Option<i32> {
-    #[cfg(target_os = "linux")]
-    {
-        use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
-        use nix::unistd::Pid;
-
-        match waitpid(Pid::from_raw(pid as i32), Some(WaitPidFlag::WNOHANG)) {
-            Ok(WaitStatus::Exited(_, code)) => Some(code),
-            Ok(WaitStatus::Signaled(_, sig, _)) => Some(128 + sig as i32),
-            _ => None,
-        }
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = pid;
-        None
-    }
-}
-
-/// Perform pivot_root to change the container's root filesystem.
-///
-/// Runs in the post-fork child, so it must be async-signal-safe: no heap
-/// allocation. Paths are pre-allocated `CStr`s; directory create/remove use
-/// `libc` directly (not `std::fs`); errors are returned as static `&str`
-/// messages for the caller to `libc::write` + `_exit`.
-#[cfg(target_os = "linux")]
-fn do_pivot_root(
-    new_root: &std::ffi::CStr,
-    old_root: &std::ffi::CStr,
-) -> Result<(), &'static [u8]> {
-    use nix::mount::{mount, umount2, MntFlags, MsFlags};
-
-    // Bind-mount new_root onto itself (required by pivot_root).
-    mount(
-        Some(new_root),
-        new_root,
-        None::<&std::ffi::CStr>,
-        MsFlags::MS_BIND | MsFlags::MS_REC,
-        None::<&std::ffi::CStr>,
-    )
-    .map_err(|_| &b"rauha-shim: bind-mount rootfs failed\n"[..])?;
-
-    // Create the pivot-old mountpoint (ignore EEXIST). libc::mkdir is
-    // async-signal-safe; std::fs would allocate.
-    unsafe {
-        libc::mkdir(old_root.as_ptr(), 0o755);
-    }
-
-    nix::unistd::pivot_root(new_root, old_root)
-        .map_err(|_| &b"rauha-shim: pivot_root failed\n"[..])?;
-    nix::unistd::chdir(c"/").map_err(|_| &b"rauha-shim: chdir(/) failed\n"[..])?;
-
-    // Unmount old root.
-    umount2(c"/.pivot_old", MntFlags::MNT_DETACH)
-        .map_err(|_| &b"rauha-shim: umount old root failed\n"[..])?;
-    unsafe {
-        libc::rmdir(c"/.pivot_old".as_ptr());
-    }
-
-    Ok(())
-}
-
-/// Redirect stdout and stderr to log files.
-#[cfg(target_os = "linux")]
-/// Redirect stdout/stderr to log files using raw open() syscall.
-///
-/// Async-signal-safe: uses pre-allocated CStrings and libc::open directly.
-/// No Rust allocation, no File::create, no global locks.
-fn redirect_stdio_raw(stdout_path: &std::ffi::CStr, stderr_path: &std::ffi::CStr) {
-    unsafe {
-        let fd = libc::open(
-            stdout_path.as_ptr(),
-            libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC,
-            0o644,
-        );
-        if fd >= 0 {
-            libc::dup2(fd, 1);
-            libc::close(fd);
-        }
-
-        let fd = libc::open(
-            stderr_path.as_ptr(),
-            libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC,
-            0o644,
-        );
-        if fd >= 0 {
-            libc::dup2(fd, 2);
-            libc::close(fd);
-        }
     }
 }

--- a/rauha-shim/src/state.rs
+++ b/rauha-shim/src/state.rs
@@ -13,14 +13,16 @@ pub struct ShimState {
 
 /// A container process tracked by the shim.
 struct ContainerProcess {
-    /// PID after fork (0 if only created, not started).
+    /// OCI init PID (0 if only created, not started).
     pid: u32,
     /// Current status.
     status: ContainerStatus,
-    /// Exit code (set after waitpid).
+    /// Exit code reported by the foreground OCI runtime.
     exit_code: Option<i32>,
     /// OCI runtime spec JSON (saved at create time, used at start time).
     spec_json: String,
+    /// Foreground crun process supervised by this shim.
+    runtime: Option<container::RuntimeProcess>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -63,13 +65,14 @@ impl ShimState {
                 status: ContainerStatus::Created,
                 exit_code: None,
                 spec_json: spec_json.to_string(),
+                runtime: None,
             },
         );
 
         Ok(0) // No PID yet — will be assigned on start.
     }
 
-    /// Start a previously created container by forking and running the workload.
+    /// Start a previously created container through crun.
     pub fn start_container(&mut self, id: &str) -> anyhow::Result<u32> {
         let proc = self
             .containers
@@ -82,14 +85,15 @@ impl ShimState {
 
         let spec_json = proc.spec_json.clone();
 
-        let pid = container::fork_and_exec(&self.zone_name, id, &spec_json, &self.rootfs_root)?;
+        let (runtime, pid) = container::start_with_crun(id, &spec_json, &self.rootfs_root)?;
 
         let proc = self
             .containers
             .get_mut(id)
-            .ok_or_else(|| anyhow::anyhow!("container {id} not found after fork"))?;
+            .ok_or_else(|| anyhow::anyhow!("container {id} not found after OCI start"))?;
         proc.pid = pid;
         proc.status = ContainerStatus::Running;
+        proc.runtime = Some(runtime);
 
         tracing::info!(container = id, pid, "container started");
         Ok(pid)
@@ -111,7 +115,10 @@ impl ShimState {
             anyhow::bail!("container {id} is not running");
         }
 
-        container::send_signal(proc.pid, signal)?;
+        proc.runtime
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("container {id} has no OCI runtime"))?
+            .signal(signal)?;
         Ok(())
     }
 
@@ -134,7 +141,7 @@ impl ShimState {
             if proc.status != ContainerStatus::Running || proc.pid == 0 {
                 continue;
             }
-            if let Some(exit_code) = container::try_wait(proc.pid) {
+            if let Some(exit_code) = proc.runtime.as_mut().and_then(|runtime| runtime.try_wait()) {
                 tracing::info!(pid = proc.pid, exit_code, "container exited");
                 proc.status = ContainerStatus::Stopped;
                 proc.exit_code = Some(exit_code);
@@ -153,6 +160,11 @@ impl ShimState {
     }
 
     pub fn request_shutdown(&mut self) {
+        for process in self.containers.values_mut() {
+            if let Some(runtime) = process.runtime.as_mut() {
+                runtime.stop_and_delete();
+            }
+        }
         self.shutdown = true;
     }
 

--- a/rauha-shim/src/state.rs
+++ b/rauha-shim/src/state.rs
@@ -21,7 +21,7 @@ struct ContainerProcess {
     exit_code: Option<i32>,
     /// OCI runtime spec JSON (saved at create time, used at start time).
     spec_json: String,
-    /// Foreground crun process supervised by this shim.
+    /// OCI init process supervised by this shim.
     runtime: Option<container::RuntimeProcess>,
 }
 
@@ -85,7 +85,8 @@ impl ShimState {
 
         let spec_json = proc.spec_json.clone();
 
-        let (runtime, pid) = container::start_with_crun(id, &spec_json, &self.rootfs_root)?;
+        let (runtime, pid) =
+            container::start_with_crun(&self.zone_name, id, &spec_json, &self.rootfs_root)?;
 
         let proc = self
             .containers

--- a/rauha-shim/src/state.rs
+++ b/rauha-shim/src/state.rs
@@ -100,9 +100,30 @@ impl ShimState {
         Ok(pid)
     }
 
-    /// Stop a container by sending a signal.
+    /// Stop a container: deliver `signal`, then escalate to SIGKILL if init
+    /// has not exited within the grace period. Returns only once init is gone.
     pub fn stop_container(&mut self, id: &str, signal: i32) -> anyhow::Result<()> {
-        self.signal_container(id, signal)
+        const GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+
+        self.signal_container(id, signal)?;
+        let proc = self
+            .containers
+            .get_mut(id)
+            .ok_or_else(|| anyhow::anyhow!("container {id} not found"))?;
+        let runtime = proc
+            .runtime
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("container {id} has no OCI runtime"))?;
+        let exit_code = runtime.wait_or_kill(GRACE);
+        tracing::info!(
+            container = id,
+            pid = proc.pid,
+            exit_code,
+            "container stopped"
+        );
+        proc.status = ContainerStatus::Stopped;
+        proc.exit_code = Some(exit_code);
+        Ok(())
     }
 
     /// Send a signal to a container's process.

--- a/rauhad/build.rs
+++ b/rauhad/build.rs
@@ -2,6 +2,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_server(true)
         .build_client(true)
+        .client_mod_attribute(
+            ".",
+            "#[allow(clippy::mixed_attributes_style, clippy::result_large_err)]",
+        )
         .compile_protos(
             &[
                 "../proto/zone.proto",

--- a/rauhad/src/backend/linux/mod.rs
+++ b/rauhad/src/backend/linux/mod.rs
@@ -376,9 +376,6 @@ fn unsupported_linux_controls(policy: &ZonePolicy) -> Vec<String> {
     if !policy.syscalls.deny.is_empty() {
         unsupported.push("syscalls.deny".to_string());
     }
-    if !policy.network.allowed_ingress.is_empty() {
-        unsupported.push("network.allowed_ingress".to_string());
-    }
     unsupported
 }
 
@@ -417,7 +414,10 @@ fn oci_capabilities(policy: &ZonePolicy) -> Result<oci_spec::runtime::LinuxCapab
         .allowed
         .iter()
         .map(|name| {
-            rauha_common::zone::canonical_linux_capability_name(name)
+            let canonical = rauha_common::zone::canonical_linux_capability_name(name);
+            canonical
+                .strip_prefix("CAP_")
+                .ok_or_else(|| RauhaError::InvalidPolicy(format!("unknown capability: {name}")))?
                 .parse::<Capability>()
                 .map_err(|_| RauhaError::InvalidPolicy(format!("unknown capability: {name}")))
         })
@@ -1667,7 +1667,7 @@ mod tests {
         policy.filesystem.writable_paths = vec!["/tmp".into()];
         policy.devices.allowed = vec!["/dev/null".into()];
         policy.syscalls.deny = vec!["mount".into()];
-        policy.network.allowed_ingress = vec!["tcp:8080".into()];
+        policy.network.allowed_ingress = vec!["0.0.0.0/0:8080".into()];
 
         assert_eq!(
             unsupported_linux_controls(&policy),
@@ -1675,7 +1675,6 @@ mod tests {
                 "filesystem.writable_paths",
                 "devices.allowed",
                 "syscalls.deny",
-                "network.allowed_ingress",
             ]
         );
 
@@ -1701,6 +1700,17 @@ mod tests {
         assert!(capabilities.inheritable().as_ref().unwrap().is_empty());
         assert!(capabilities.permitted().as_ref().unwrap().is_empty());
         assert!(capabilities.ambient().as_ref().unwrap().is_empty());
+    }
+
+    #[test]
+    fn named_policy_capabilities_convert_to_oci_capabilities() {
+        let mut policy = ZonePolicy::default();
+        policy.capabilities.allowed = vec!["CAP_NET_RAW".into(), "chown".into()];
+
+        let capabilities = oci_capabilities(&policy).unwrap();
+        let effective = capabilities.effective().as_ref().unwrap();
+        assert!(effective.contains(&oci_spec::runtime::Capability::NetRaw));
+        assert!(effective.contains(&oci_spec::runtime::Capability::Chown));
     }
 
     #[test]

--- a/rauhad/src/backend/linux/mod.rs
+++ b/rauhad/src/backend/linux/mod.rs
@@ -433,34 +433,6 @@ fn oci_capabilities(policy: &ZonePolicy) -> Result<oci_spec::runtime::LinuxCapab
         .map_err(|e| RauhaError::BackendError(format!("failed to build OCI capabilities: {e}")))
 }
 
-/// Keep crun's trusted setup outside the zone, then enroll PID 1 before image code runs.
-fn add_crun_zone_boundary(spec: &mut serde_json::Value, zone_name: &str) -> Result<()> {
-    let object = spec.as_object_mut().ok_or_else(|| {
-        RauhaError::BackendError("generated OCI spec is not a JSON object".into())
-    })?;
-    let mounts = object
-        .get_mut("mounts")
-        .and_then(serde_json::Value::as_array_mut)
-        .ok_or_else(|| RauhaError::BackendError("generated OCI mounts are missing".into()))?;
-    mounts.push(serde_json::json!({
-        "destination": "/run/rauha-zone.procs",
-        "type": "bind",
-        "source": format!("/sys/fs/cgroup/rauha.slice/zone-{zone_name}/cgroup.procs"),
-        "options": ["bind", "rw", "nosuid", "noexec", "nodev"]
-    }));
-    object.insert(
-        "hooks".into(),
-        serde_json::json!({
-            "startContainer": [{
-                "path": "/bin/sh",
-                "args": ["sh", "-c", "printf 1 > /run/rauha-zone.procs"],
-                "env": ["PATH=/usr/sbin:/usr/bin:/sbin:/bin"]
-            }]
-        }),
-    );
-    Ok(())
-}
-
 fn collect_zone_rootfs_inodes(root: &str, zone_name: &str) -> Result<Vec<u64>> {
     let containers = PathBuf::from(root)
         .join("zones")
@@ -1037,18 +1009,6 @@ impl IsolationBackend for LinuxBackend {
             tracing::warn!(%e, "failed to write resolv.conf — DNS may not work inside container");
         }
 
-        // crun otherwise creates this bind target after inode registration,
-        // making the enforced rootfs set stale as the container starts.
-        let cgroup_target = rootfs_dir.join("run/rauha-zone.procs");
-        if let Some(parent) = cgroup_target.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| RauhaError::RootfsError {
-                message: format!("failed to create OCI hook directory: {e}"),
-            })?;
-        }
-        std::fs::File::create(&cgroup_target).map_err(|e| RauhaError::RootfsError {
-            message: format!("failed to create OCI cgroup bind target: {e}"),
-        })?;
-
         // Generate OCI runtime spec.
         use oci_spec::runtime::{LinuxBuilder, LinuxNamespaceBuilder, LinuxNamespaceType};
         let mut namespaces = vec![
@@ -1084,7 +1044,7 @@ impl IsolationBackend for LinuxBackend {
             .map_err(|e| {
                 RauhaError::BackendError(format!("failed to build OCI Linux spec: {e}"))
             })?;
-        let mut runtime_spec = serde_json::to_value(
+        let runtime_spec = serde_json::to_value(
             oci_spec::runtime::SpecBuilder::default()
                 .version("1.0.2")
                 .root(
@@ -1126,7 +1086,6 @@ impl IsolationBackend for LinuxBackend {
                 .unwrap(),
         )
         .map_err(|e| RauhaError::BackendError(format!("failed to serialize spec: {e}")))?;
-        add_crun_zone_boundary(&mut runtime_spec, &zone.name)?;
         let spec_json = serde_json::to_string(&runtime_spec)
             .map_err(|e| RauhaError::BackendError(format!("failed to serialize spec: {e}")))?;
 
@@ -1639,8 +1598,8 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::{
-        add_crun_zone_boundary, admit_linux_policy, collect_zone_rootfs_inodes, lock_backend,
-        oci_capabilities, unsupported_linux_controls,
+        admit_linux_policy, collect_zone_rootfs_inodes, lock_backend, oci_capabilities,
+        unsupported_linux_controls,
     };
     use rauha_common::zone::{PolicyAdmission, ZonePolicy};
     use std::os::unix::fs::MetadataExt;
@@ -1711,22 +1670,6 @@ mod tests {
         let effective = capabilities.effective().as_ref().unwrap();
         assert!(effective.contains(&oci_spec::runtime::Capability::NetRaw));
         assert!(effective.contains(&oci_spec::runtime::Capability::Chown));
-    }
-
-    #[test]
-    fn crun_enrolls_init_before_releasing_the_workload() {
-        let mut spec = serde_json::json!({"mounts": [{"destination": "/dev"}]});
-        add_crun_zone_boundary(&mut spec, "test").unwrap();
-
-        assert_eq!(spec["mounts"][0]["destination"], "/dev");
-        assert_eq!(
-            spec["mounts"][1]["source"],
-            "/sys/fs/cgroup/rauha.slice/zone-test/cgroup.procs"
-        );
-        assert_eq!(
-            spec["hooks"]["startContainer"][0]["args"][2],
-            "printf 1 > /run/rauha-zone.procs"
-        );
     }
 
     #[test]

--- a/rauhad/src/backend/linux/mod.rs
+++ b/rauhad/src/backend/linux/mod.rs
@@ -29,8 +29,9 @@ pub fn cleanup_network() {
 }
 
 use std::collections::{BTreeSet, HashMap};
+use std::os::unix::fs::MetadataExt;
 use std::os::unix::net::UnixStream;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Mutex, MutexGuard};
@@ -367,16 +368,46 @@ impl LinuxBackend {
 
 fn unsupported_linux_controls(policy: &ZonePolicy) -> Vec<String> {
     let mut unsupported = Vec::new();
-    if !policy.filesystem.writable_paths.is_empty() {
+    if policy
+        .filesystem
+        .writable_paths
+        .iter()
+        .any(|path| !safe_writable_path(path))
+    {
         unsupported.push("filesystem.writable_paths".to_string());
     }
-    if !policy.devices.allowed.is_empty() {
+    if policy
+        .devices
+        .allowed
+        .iter()
+        .any(|path| device_numbers(path).is_none())
+    {
         unsupported.push("devices.allowed".to_string());
     }
-    if !policy.syscalls.deny.is_empty() {
-        unsupported.push("syscalls.deny".to_string());
-    }
     unsupported
+}
+
+fn safe_writable_path(path: &str) -> bool {
+    let path = Path::new(path);
+    path.is_absolute()
+        && path != Path::new("/")
+        && !["/proc", "/sys", "/dev", "/run"]
+            .iter()
+            .any(|reserved| path.starts_with(reserved))
+        && path
+            .components()
+            .all(|component| matches!(component, Component::RootDir | Component::Normal(_)))
+}
+
+fn device_numbers(path: &str) -> Option<(i64, i64)> {
+    match path {
+        "/dev/null" => Some((1, 3)),
+        "/dev/zero" => Some((1, 5)),
+        "/dev/full" => Some((1, 7)),
+        "/dev/random" => Some((1, 8)),
+        "/dev/urandom" => Some((1, 9)),
+        _ => None,
+    }
 }
 
 fn admit_linux_policy(policy: &ZonePolicy, skipped_hooks: &[String]) -> Result<()> {
@@ -431,6 +462,117 @@ fn oci_capabilities(policy: &ZonePolicy) -> Result<oci_spec::runtime::LinuxCapab
         .ambient(capabilities)
         .build()
         .map_err(|e| RauhaError::BackendError(format!("failed to build OCI capabilities: {e}")))
+}
+
+fn oci_seccomp(policy: &ZonePolicy) -> Result<Option<oci_spec::runtime::LinuxSeccomp>> {
+    use oci_spec::runtime::{LinuxSeccompAction, LinuxSeccompBuilder, LinuxSyscallBuilder};
+
+    if policy.syscalls.deny.is_empty() {
+        return Ok(None);
+    }
+    let denied = LinuxSyscallBuilder::default()
+        .names(policy.syscalls.deny.clone())
+        .action(LinuxSeccompAction::ScmpActErrno)
+        .errno_ret(libc::EPERM as u32)
+        .build()
+        .map_err(|error| {
+            RauhaError::BackendError(format!("failed to build OCI seccomp rule: {error}"))
+        })?;
+    LinuxSeccompBuilder::default()
+        .default_action(LinuxSeccompAction::ScmpActAllow)
+        .syscalls(vec![denied])
+        .build()
+        .map(Some)
+        .map_err(|error| {
+            RauhaError::BackendError(format!("failed to build OCI seccomp profile: {error}"))
+        })
+}
+
+fn oci_devices(policy: &ZonePolicy) -> Result<Vec<oci_spec::runtime::LinuxDevice>> {
+    use oci_spec::runtime::{LinuxDeviceBuilder, LinuxDeviceType};
+
+    policy
+        .devices
+        .allowed
+        .iter()
+        .filter_map(|path| device_numbers(path).map(|numbers| (path, numbers)))
+        .map(|(path, (major, minor))| {
+            LinuxDeviceBuilder::default()
+                .path(path)
+                .typ(LinuxDeviceType::C)
+                .major(major)
+                .minor(minor)
+                .file_mode(0o666u32)
+                .uid(0u32)
+                .gid(0u32)
+                .build()
+                .map_err(|error| {
+                    RauhaError::BackendError(format!("failed to build OCI device {path}: {error}"))
+                })
+        })
+        .collect()
+}
+
+fn oci_mounts(policy: &ZonePolicy, rootfs: &Path) -> Result<Vec<oci_spec::runtime::Mount>> {
+    use oci_spec::runtime::{get_default_mounts, MountBuilder};
+
+    let mut mounts = get_default_mounts();
+    for declared in policy
+        .filesystem
+        .writable_paths
+        .iter()
+        .filter(|path| safe_writable_path(path))
+    {
+        let relative = declared.trim_start_matches('/');
+        let mut current = rootfs.to_path_buf();
+        for component in Path::new(relative).components() {
+            let Component::Normal(component) = component else {
+                return Err(RauhaError::InvalidPolicy(format!(
+                    "unsafe writable path: {declared}"
+                )));
+            };
+            current.push(component);
+            let metadata = std::fs::symlink_metadata(&current).map_err(|error| {
+                RauhaError::InvalidPolicy(format!(
+                    "writable path {declared} is not present in the image: {error}"
+                ))
+            })?;
+            if metadata.file_type().is_symlink() {
+                return Err(RauhaError::InvalidPolicy(format!(
+                    "writable path crosses a symlink: {declared}"
+                )));
+            }
+        }
+        let metadata = std::fs::metadata(&current).map_err(|error| RauhaError::RootfsError {
+            message: format!("failed to inspect writable path {declared}: {error}"),
+        })?;
+        if !metadata.is_dir() {
+            return Err(RauhaError::InvalidPolicy(format!(
+                "writable path is not a directory: {declared}"
+            )));
+        }
+        mounts.push(
+            MountBuilder::default()
+                .destination(declared)
+                .typ("tmpfs")
+                .source("tmpfs")
+                .options(vec![
+                    "rw".into(),
+                    "nosuid".into(),
+                    "nodev".into(),
+                    "noexec".into(),
+                    format!("mode={:o}", metadata.mode() & 0o7777),
+                    "size=65536k".into(),
+                ])
+                .build()
+                .map_err(|error| {
+                    RauhaError::BackendError(format!(
+                        "failed to build OCI mount {declared}: {error}"
+                    ))
+                })?,
+        );
+    }
+    Ok(mounts)
 }
 
 fn collect_zone_rootfs_inodes(root: &str, zone_name: &str) -> Result<Vec<u64>> {
@@ -1038,22 +1180,29 @@ impl IsolationBackend for LinuxBackend {
                     .unwrap(),
             );
         }
-        let linux = LinuxBuilder::default()
+        let mut linux = LinuxBuilder::default()
             .namespaces(namespaces)
+            .devices(oci_devices(&policy)?)
             .build()
             .map_err(|e| {
                 RauhaError::BackendError(format!("failed to build OCI Linux spec: {e}"))
             })?;
+        if let Some(seccomp) = oci_seccomp(&policy)? {
+            linux.set_seccomp(Some(seccomp));
+        }
+        let mounts = oci_mounts(&policy, &rootfs_dir)?;
         let runtime_spec = serde_json::to_value(
             oci_spec::runtime::SpecBuilder::default()
+                .annotations(HashMap::from([(
+                    "run.oci.seccomp_fail_unknown_syscall".to_string(),
+                    "1".to_string(),
+                )]))
+                .mounts(mounts)
                 .version("1.0.2")
                 .root(
                     oci_spec::runtime::RootBuilder::default()
                         .path(rootfs_dir.to_string_lossy().as_ref())
-                        // An empty writable-path allow-list means allow no
-                        // writes. crun remounts this root read-only before
-                        // releasing the workload.
-                        .readonly(policy.filesystem.writable_paths.is_empty())
+                        .readonly(true)
                         .build()
                         .unwrap(),
                 )
@@ -1599,7 +1748,7 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<()
 mod tests {
     use super::{
         admit_linux_policy, collect_zone_rootfs_inodes, lock_backend, oci_capabilities,
-        unsupported_linux_controls,
+        oci_devices, oci_mounts, oci_seccomp, unsupported_linux_controls,
     };
     use rauha_common::zone::{PolicyAdmission, ZonePolicy};
     use std::os::unix::fs::MetadataExt;
@@ -1623,18 +1772,14 @@ mod tests {
     #[test]
     fn strict_admission_rejects_unsupported_controls() {
         let mut policy = ZonePolicy::default();
-        policy.filesystem.writable_paths = vec!["/tmp".into()];
-        policy.devices.allowed = vec!["/dev/null".into()];
+        policy.filesystem.writable_paths = vec!["/proc".into()];
+        policy.devices.allowed = vec!["/dev/sda".into()];
         policy.syscalls.deny = vec!["mount".into()];
         policy.network.allowed_ingress = vec!["0.0.0.0/0:8080".into()];
 
         assert_eq!(
             unsupported_linux_controls(&policy),
-            vec![
-                "filesystem.writable_paths",
-                "devices.allowed",
-                "syscalls.deny",
-            ]
+            vec!["filesystem.writable_paths", "devices.allowed",]
         );
 
         let err = admit_linux_policy(&policy, &[]).expect_err("strict policy must fail closed");
@@ -1642,6 +1787,26 @@ mod tests {
 
         policy.admission = PolicyAdmission::Audit;
         admit_linux_policy(&policy, &[]).expect("audit mode explicitly accepts degraded admission");
+    }
+
+    #[test]
+    fn supported_controls_build_oci_seccomp_devices_and_mounts() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("tmp")).unwrap();
+        let mut policy = ZonePolicy::default();
+        policy.filesystem.writable_paths = vec!["/tmp".into()];
+        policy.devices.allowed = vec!["/dev/null".into()];
+        policy.syscalls.deny = vec!["mount".into()];
+
+        assert!(unsupported_linux_controls(&policy).is_empty());
+        assert_eq!(oci_devices(&policy).unwrap().len(), 1);
+        assert!(oci_seccomp(&policy).unwrap().is_some());
+        let mounts = serde_json::to_value(oci_mounts(&policy, root.path()).unwrap()).unwrap();
+        assert!(mounts
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|mount| mount["destination"] == "/tmp"));
     }
 
     #[test]

--- a/rauhad/src/backend/linux/mod.rs
+++ b/rauhad/src/backend/linux/mod.rs
@@ -433,6 +433,34 @@ fn oci_capabilities(policy: &ZonePolicy) -> Result<oci_spec::runtime::LinuxCapab
         .map_err(|e| RauhaError::BackendError(format!("failed to build OCI capabilities: {e}")))
 }
 
+/// Keep crun's trusted setup outside the zone, then enroll PID 1 before image code runs.
+fn add_crun_zone_boundary(spec: &mut serde_json::Value, zone_name: &str) -> Result<()> {
+    let object = spec.as_object_mut().ok_or_else(|| {
+        RauhaError::BackendError("generated OCI spec is not a JSON object".into())
+    })?;
+    let mounts = object
+        .get_mut("mounts")
+        .and_then(serde_json::Value::as_array_mut)
+        .ok_or_else(|| RauhaError::BackendError("generated OCI mounts are missing".into()))?;
+    mounts.push(serde_json::json!({
+        "destination": "/run/rauha-zone.procs",
+        "type": "bind",
+        "source": format!("/sys/fs/cgroup/rauha.slice/zone-{zone_name}/cgroup.procs"),
+        "options": ["bind", "rw", "nosuid", "noexec", "nodev"]
+    }));
+    object.insert(
+        "hooks".into(),
+        serde_json::json!({
+            "startContainer": [{
+                "path": "/bin/sh",
+                "args": ["sh", "-c", "printf 1 > /run/rauha-zone.procs"],
+                "env": ["PATH=/usr/sbin:/usr/bin:/sbin:/bin"]
+            }]
+        }),
+    );
+    Ok(())
+}
+
 fn collect_zone_rootfs_inodes(root: &str, zone_name: &str) -> Result<Vec<u64>> {
     let containers = PathBuf::from(root)
         .join("zones")
@@ -1009,6 +1037,18 @@ impl IsolationBackend for LinuxBackend {
             tracing::warn!(%e, "failed to write resolv.conf — DNS may not work inside container");
         }
 
+        // crun otherwise creates this bind target after inode registration,
+        // making the enforced rootfs set stale as the container starts.
+        let cgroup_target = rootfs_dir.join("run/rauha-zone.procs");
+        if let Some(parent) = cgroup_target.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| RauhaError::RootfsError {
+                message: format!("failed to create OCI hook directory: {e}"),
+            })?;
+        }
+        std::fs::File::create(&cgroup_target).map_err(|e| RauhaError::RootfsError {
+            message: format!("failed to create OCI cgroup bind target: {e}"),
+        })?;
+
         // Generate OCI runtime spec.
         use oci_spec::runtime::{LinuxBuilder, LinuxNamespaceBuilder, LinuxNamespaceType};
         let mut namespaces = vec![
@@ -1044,14 +1084,14 @@ impl IsolationBackend for LinuxBackend {
             .map_err(|e| {
                 RauhaError::BackendError(format!("failed to build OCI Linux spec: {e}"))
             })?;
-        let spec_json = serde_json::to_string(
-            &oci_spec::runtime::SpecBuilder::default()
+        let mut runtime_spec = serde_json::to_value(
+            oci_spec::runtime::SpecBuilder::default()
                 .version("1.0.2")
                 .root(
                     oci_spec::runtime::RootBuilder::default()
                         .path(rootfs_dir.to_string_lossy().as_ref())
                         // An empty writable-path allow-list means allow no
-                        // writes. The shim remounts this root read-only before
+                        // writes. crun remounts this root read-only before
                         // releasing the workload.
                         .readonly(policy.filesystem.writable_paths.is_empty())
                         .build()
@@ -1086,6 +1126,9 @@ impl IsolationBackend for LinuxBackend {
                 .unwrap(),
         )
         .map_err(|e| RauhaError::BackendError(format!("failed to serialize spec: {e}")))?;
+        add_crun_zone_boundary(&mut runtime_spec, &zone.name)?;
+        let spec_json = serde_json::to_string(&runtime_spec)
+            .map_err(|e| RauhaError::BackendError(format!("failed to serialize spec: {e}")))?;
 
         // Register rootfs inodes in BPF map for file isolation.
         // Phase 1: Collect inodes from filesystem (no lock, may be slow for large rootfs).
@@ -1596,8 +1639,8 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::{
-        admit_linux_policy, collect_zone_rootfs_inodes, lock_backend, oci_capabilities,
-        unsupported_linux_controls,
+        add_crun_zone_boundary, admit_linux_policy, collect_zone_rootfs_inodes, lock_backend,
+        oci_capabilities, unsupported_linux_controls,
     };
     use rauha_common::zone::{PolicyAdmission, ZonePolicy};
     use std::os::unix::fs::MetadataExt;
@@ -1658,6 +1701,22 @@ mod tests {
         assert!(capabilities.inheritable().as_ref().unwrap().is_empty());
         assert!(capabilities.permitted().as_ref().unwrap().is_empty());
         assert!(capabilities.ambient().as_ref().unwrap().is_empty());
+    }
+
+    #[test]
+    fn crun_enrolls_init_before_releasing_the_workload() {
+        let mut spec = serde_json::json!({"mounts": [{"destination": "/dev"}]});
+        add_crun_zone_boundary(&mut spec, "test").unwrap();
+
+        assert_eq!(spec["mounts"][0]["destination"], "/dev");
+        assert_eq!(
+            spec["mounts"][1]["source"],
+            "/sys/fs/cgroup/rauha.slice/zone-test/cgroup.procs"
+        );
+        assert_eq!(
+            spec["hooks"]["startContainer"][0]["args"][2],
+            "printf 1 > /run/rauha-zone.procs"
+        );
     }
 
     #[test]

--- a/rauhad/src/backend/linux/mod.rs
+++ b/rauhad/src/backend/linux/mod.rs
@@ -517,6 +517,9 @@ fn oci_mounts(policy: &ZonePolicy, rootfs: &Path) -> Result<Vec<oci_spec::runtim
     use oci_spec::runtime::{get_default_mounts, MountBuilder};
 
     let mut mounts = get_default_mounts();
+    // The host cgroup2 hierarchy names every zone and exposes its live
+    // counters; the workload has no use for it.
+    mounts.retain(|mount| mount.destination() != Path::new("/sys/fs/cgroup"));
     for declared in policy
         .filesystem
         .writable_paths
@@ -1168,6 +1171,10 @@ impl IsolationBackend for LinuxBackend {
                 .unwrap(),
             LinuxNamespaceBuilder::default()
                 .typ(LinuxNamespaceType::Pid)
+                .build()
+                .unwrap(),
+            LinuxNamespaceBuilder::default()
+                .typ(LinuxNamespaceType::Cgroup)
                 .build()
                 .unwrap(),
         ];

--- a/rauhad/src/backend/linux/nftables.rs
+++ b/rauhad/src/backend/linux/nftables.rs
@@ -37,6 +37,11 @@ pub fn ensure_nat(subnet_cidr: &str) -> Result<()> {
     Ok(())
 }
 
+/// Every bridge base chain is `policy drop`: a zone only has connectivity
+/// through the per-zone jump rules installed by `apply_zone_rules`, so a zone
+/// whose rules failed to apply, or whose rules are mid-replacement, is cut off
+/// rather than left open. The inet forward `iifname "rauha0"` accept is only
+/// reachable for frames that already passed a bridge input chain.
 fn base_ruleset(subnet_cidr: &str, replace_inet: bool, replace_bridge: bool) -> String {
     format!(
         "{delete_inet}{delete_bridge}add table inet rauha\n\
@@ -51,8 +56,8 @@ fn base_ruleset(subnet_cidr: &str, replace_inet: bool, replace_bridge: bool) -> 
          add rule inet rauha input iifname \"rauha0\" drop\n\
          add table bridge rauha\n\
          add chain bridge rauha forward {{ type filter hook forward priority filter; policy drop; }}\n\
-         add chain bridge rauha input {{ type filter hook input priority filter; policy accept; }}\n\
-         add chain bridge rauha output {{ type filter hook output priority filter; policy accept; }}\n",
+         add chain bridge rauha input {{ type filter hook input priority filter; policy drop; }}\n\
+         add chain bridge rauha output {{ type filter hook output priority filter; policy drop; }}\n",
         delete_inet = if replace_inet {
             "delete table inet rauha\n"
         } else {
@@ -348,6 +353,15 @@ fn endpoint_rules(address_match: &str, targets: &[String]) -> Result<Vec<String>
     targets
         .iter()
         .map(|target| {
+            // Zones persisted before ports became mandatory-nonzero used
+            // `addr:0` to mean "any port"; keep those zones loadable.
+            let target = match target.strip_suffix(":0") {
+                Some(network) if network.parse::<NetworkEndpoint>().is_ok() => {
+                    tracing::warn!(target, "legacy ':0' network target treated as any port");
+                    network
+                }
+                _ => target.as_str(),
+            };
             let endpoint = target.parse::<NetworkEndpoint>().map_err(|error| {
                 RauhaError::InvalidPolicy(format!("invalid network target {target:?}: {error}"))
             })?;
@@ -463,6 +477,12 @@ mod tests {
             "delete table inet rauha\ndelete table bridge rauha\nadd table inet rauha"
         ));
         assert!(rules.contains("add chain bridge rauha forward"));
+        for chain in ["forward", "input", "output"] {
+            assert!(
+                rules.contains(&format!("add chain bridge rauha {chain} {{ type filter hook {chain} priority filter; policy drop; }}")),
+                "bridge {chain} chain must fail closed"
+            );
+        }
         assert!(rules.contains("add rule inet rauha input iifname \"rauha0\" drop"));
         assert!(rules.contains("ip saddr 10.89.0.0/16"));
     }
@@ -498,6 +518,12 @@ mod tests {
                 "ip6 daddr 2001:db8::/32 accept",
             ]
         );
+    }
+
+    #[test]
+    fn endpoint_rules_accept_legacy_port_zero_as_any_port() {
+        let rules = endpoint_rules("daddr", &["0.0.0.0/0:0".into()]).unwrap();
+        assert_eq!(rules, ["ip daddr 0.0.0.0/0 accept"]);
     }
 
     #[test]

--- a/rauhad/src/backend/linux/nftables.rs
+++ b/rauhad/src/backend/linux/nftables.rs
@@ -2,7 +2,8 @@
 //!
 //! Handles two concerns:
 //! 1. NAT masquerade — zones can reach the internet via the host
-//! 2. Forward chain filtering — controls cross-zone and egress traffic
+//! 2. Inet filtering — controls routed egress and blocks zone-to-host traffic
+//! 3. Bridge filtering — controls same-subnet cross-zone traffic at layer 2
 //!
 //! nftables is the primary network enforcement layer. eBPF stays focused on
 //! syscall policy (file_open, ptrace, etc). This separation keeps each
@@ -12,17 +13,22 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 
 use rauha_common::error::{RauhaError, Result};
-use rauha_common::zone::{NetworkMode, NetworkPolicy};
+use rauha_common::zone::{NetworkEndpoint, NetworkMode, NetworkPolicy};
 
 const TABLE_NAME: &str = "rauha";
 const TABLE_FAMILY: &str = "inet";
+const BRIDGE_FAMILY: &str = "bridge";
 
 /// Ensure the rauha nftables table and NAT masquerade chain exist.
 /// Called once during LinuxBackend::new().
 pub fn ensure_nat(subnet_cidr: &str) -> Result<()> {
     // nft -f applies the complete batch as one kernel transaction. A syntax or
     // runtime failure therefore leaves the previous enforcement table intact.
-    run_nft_script(&base_ruleset(subnet_cidr, table_exists()?))?;
+    run_nft_script(&base_ruleset(
+        subnet_cidr,
+        table_exists(TABLE_FAMILY)?,
+        table_exists(BRIDGE_FAMILY)?,
+    ))?;
 
     tracing::info!(
         subnet = subnet_cidr,
@@ -31,30 +37,45 @@ pub fn ensure_nat(subnet_cidr: &str) -> Result<()> {
     Ok(())
 }
 
-fn base_ruleset(subnet_cidr: &str, replace: bool) -> String {
+fn base_ruleset(subnet_cidr: &str, replace_inet: bool, replace_bridge: bool) -> String {
     format!(
-        "{delete}add table inet rauha\n\
+        "{delete_inet}{delete_bridge}add table inet rauha\n\
          add chain inet rauha postrouting {{ type nat hook postrouting priority srcnat; }}\n\
          add rule inet rauha postrouting ip saddr {subnet_cidr} oifname != \"rauha0\" masquerade\n\
          add chain inet rauha forward {{ type filter hook forward priority filter; policy drop; }}\n\
-         add rule inet rauha forward ct state established,related accept\n",
-        delete = if replace {
+         add rule inet rauha forward ct state established,related accept\n\
+         add rule inet rauha forward iifname \"rauha0\" accept\n\
+         add rule inet rauha forward oifname \"rauha0\" accept\n\
+         add chain inet rauha input {{ type filter hook input priority filter; policy accept; }}\n\
+         add rule inet rauha input ct state established,related accept\n\
+         add rule inet rauha input iifname \"rauha0\" drop\n\
+         add table bridge rauha\n\
+         add chain bridge rauha forward {{ type filter hook forward priority filter; policy drop; }}\n\
+         add chain bridge rauha input {{ type filter hook input priority filter; policy accept; }}\n\
+         add chain bridge rauha output {{ type filter hook output priority filter; policy accept; }}\n",
+        delete_inet = if replace_inet {
             "delete table inet rauha\n"
         } else {
             ""
-        }
+        },
+        delete_bridge = if replace_bridge {
+            "delete table bridge rauha\n"
+        } else {
+            ""
+        },
     )
 }
 
 /// Remove the entire rauha nftables table.
 /// Called during daemon shutdown.
 pub fn cleanup_nat() -> Result<()> {
-    if !table_exists()? {
-        return Ok(());
+    if table_exists(TABLE_FAMILY)? {
+        run_nft(&["delete", "table", TABLE_FAMILY, TABLE_NAME])?;
     }
-
-    run_nft(&["delete", "table", TABLE_FAMILY, TABLE_NAME])?;
-    tracing::info!("nftables table removed");
+    if table_exists(BRIDGE_FAMILY)? {
+        run_nft(&["delete", "table", BRIDGE_FAMILY, TABLE_NAME])?;
+    }
+    tracing::info!("nftables tables removed");
     Ok(())
 }
 
@@ -63,35 +84,43 @@ pub fn cleanup_nat() -> Result<()> {
 /// Zone names are validated by `validate_zone_name` (alphanumeric + hyphen,
 /// max 128 chars) which produces safe nftables chain identifiers.
 pub fn apply_zone_rules(zone_name: &str, veth_name: &str, policy: &NetworkPolicy) -> Result<()> {
-    // First remove any existing rules for this zone.
+    let bridge_rules = bridge_zone_chain_rules(veth_name, policy);
+    let bridge_input_rules = bridge_input_chain_rules(policy)?;
+    let bridge_output_rules = bridge_output_chain_rules(policy)?;
+
+    // Removal is fail-closed: the base chains deny traffic until the complete
+    // replacement is accepted as one nft transaction.
     let _ = remove_zone_rules(zone_name);
 
-    let chain_name = zone_chain_name(zone_name);
-
     if policy.mode != NetworkMode::Host {
-        run_nft(&["add", "chain", TABLE_FAMILY, TABLE_NAME, &chain_name])?;
-        for rule in zone_chain_rules(veth_name, policy) {
-            run_nft(&["add", "rule", TABLE_FAMILY, TABLE_NAME, &chain_name, &rule])?;
+        let chain_name = zone_chain_name(zone_name);
+        let input_chain_name = zone_input_chain_name(zone_name);
+        let output_chain_name = zone_output_chain_name(zone_name);
+        let mut script = format!(
+            "add chain bridge rauha {chain_name}\n\
+             add chain bridge rauha {input_chain_name}\n\
+             add chain bridge rauha {output_chain_name}\n"
+        );
+        for rule in bridge_rules {
+            script.push_str(&format!("add rule bridge rauha {chain_name} {rule}\n"));
         }
-        // Check both endpoints. Zone chains return instead of dropping, so an
-        // allow declared by either endpoint wins regardless of creation order;
-        // the base chain remains the final default deny.
-        run_nft(&[
-            "add",
-            "rule",
-            TABLE_FAMILY,
-            TABLE_NAME,
-            "forward",
-            &format!("iifname \"{veth_name}\" jump {chain_name}"),
-        ])?;
-        run_nft(&[
-            "add",
-            "rule",
-            TABLE_FAMILY,
-            TABLE_NAME,
-            "forward",
-            &format!("oifname \"{veth_name}\" jump {chain_name}"),
-        ])?;
+        for rule in bridge_input_rules {
+            script.push_str(&format!(
+                "add rule bridge rauha {input_chain_name} {rule}\n"
+            ));
+        }
+        for rule in bridge_output_rules {
+            script.push_str(&format!(
+                "add rule bridge rauha {output_chain_name} {rule}\n"
+            ));
+        }
+        script.push_str(&format!(
+            "add rule bridge rauha forward iifname \"{veth_name}\" jump {chain_name}\n\
+             add rule bridge rauha forward oifname \"{veth_name}\" jump {chain_name}\n\
+             add rule bridge rauha input iifname \"{veth_name}\" jump {input_chain_name}\n\
+             add rule bridge rauha output oifname \"{veth_name}\" jump {output_chain_name}\n"
+        ));
+        run_nft_script(&script)?;
     }
 
     tracing::info!(zone = zone_name, mode = ?policy.mode, "nftables rules applied");
@@ -101,13 +130,20 @@ pub fn apply_zone_rules(zone_name: &str, veth_name: &str, policy: &NetworkPolicy
 /// Remove all nftables rules for a zone.
 pub fn remove_zone_rules(zone_name: &str) -> Result<()> {
     let chain_name = zone_chain_name(zone_name);
+    let input_chain_name = zone_input_chain_name(zone_name);
+    let output_chain_name = zone_output_chain_name(zone_name);
 
-    // First, remove jump rules in the forward chain that reference this zone chain.
-    let _ = remove_forward_chain_jumps(&chain_name);
-
-    // Flush and delete the zone chain. Ignore errors — chain may not exist.
-    let _ = run_nft(&["flush", "chain", TABLE_FAMILY, TABLE_NAME, &chain_name]);
-    let _ = run_nft(&["delete", "chain", TABLE_FAMILY, TABLE_NAME, &chain_name]);
+    let _ = remove_chain_jumps(BRIDGE_FAMILY, "forward", &chain_name);
+    let _ = remove_chain_jumps(BRIDGE_FAMILY, "input", &input_chain_name);
+    let _ = remove_chain_jumps(BRIDGE_FAMILY, "output", &output_chain_name);
+    for (family, chain) in [
+        (BRIDGE_FAMILY, chain_name.as_str()),
+        (BRIDGE_FAMILY, input_chain_name.as_str()),
+        (BRIDGE_FAMILY, output_chain_name.as_str()),
+    ] {
+        let _ = run_nft(&["flush", "chain", family, TABLE_NAME, chain]);
+        let _ = run_nft(&["delete", "chain", family, TABLE_NAME, chain]);
+    }
 
     Ok(())
 }
@@ -117,34 +153,114 @@ pub fn zone_rules_exist(zone_name: &str, veth_name: &str, policy: &NetworkPolicy
         return true;
     }
     let chain_name = zone_chain_name(zone_name);
-    let chain = Command::new("nft")
-        .args(["list", "chain", TABLE_FAMILY, TABLE_NAME, &chain_name])
+    let input_chain_name = zone_input_chain_name(zone_name);
+    let output_chain_name = zone_output_chain_name(zone_name);
+    let bridge_chain = Command::new("nft")
+        .args(["list", "chain", BRIDGE_FAMILY, TABLE_NAME, &chain_name])
         .output();
-    let forward = Command::new("nft")
-        .args(["list", "chain", TABLE_FAMILY, TABLE_NAME, "forward"])
+    let bridge_input_chain = Command::new("nft")
+        .args([
+            "list",
+            "chain",
+            BRIDGE_FAMILY,
+            TABLE_NAME,
+            &input_chain_name,
+        ])
         .output();
-    chain.is_ok_and(|output| {
+    let bridge_output_chain = Command::new("nft")
+        .args([
+            "list",
+            "chain",
+            BRIDGE_FAMILY,
+            TABLE_NAME,
+            &output_chain_name,
+        ])
+        .output();
+    let bridge_forward = Command::new("nft")
+        .args(["list", "chain", BRIDGE_FAMILY, TABLE_NAME, "forward"])
+        .output();
+    let bridge_input = Command::new("nft")
+        .args(["list", "chain", BRIDGE_FAMILY, TABLE_NAME, "input"])
+        .output();
+    let bridge_output = Command::new("nft")
+        .args(["list", "chain", BRIDGE_FAMILY, TABLE_NAME, "output"])
+        .output();
+    bridge_chain.is_ok_and(|output| {
         output.status.success()
-            && nft_chain_rules(&output.stdout, &chain_name) == zone_chain_rules(veth_name, policy)
-    }) && forward.is_ok_and(|output| {
-        if !output.status.success() {
-            return false;
-        }
-        let rules = String::from_utf8_lossy(&output.stdout);
-        rules.contains(&format!("iifname \"{veth_name}\" jump {chain_name}"))
-            && rules.contains(&format!("oifname \"{veth_name}\" jump {chain_name}"))
-    })
+            && nft_chain_rules(&output.stdout, &chain_name)
+                == bridge_zone_chain_rules(veth_name, policy)
+    }) && bridge_input_chain.is_ok_and(|output| {
+        output.status.success()
+            && bridge_input_chain_rules(policy)
+                .is_ok_and(|rules| nft_chain_rules(&output.stdout, &input_chain_name) == rules)
+    }) && bridge_output_chain.is_ok_and(|output| {
+        output.status.success()
+            && bridge_output_chain_rules(policy)
+                .is_ok_and(|rules| nft_chain_rules(&output.stdout, &output_chain_name) == rules)
+    }) && bridge_forward.is_ok_and(|output| forward_has_jumps(&output, veth_name, &chain_name))
+        && bridge_input
+            .is_ok_and(|output| chain_has_jump(&output, "iifname", veth_name, &input_chain_name))
+        && bridge_output
+            .is_ok_and(|output| chain_has_jump(&output, "oifname", veth_name, &output_chain_name))
 }
 
-fn zone_chain_rules(veth_name: &str, policy: &NetworkPolicy) -> Vec<String> {
-    if policy.mode == NetworkMode::Isolated {
-        return vec!["return".into()];
+fn forward_has_jumps(output: &std::process::Output, veth_name: &str, chain_name: &str) -> bool {
+    if !output.status.success() {
+        return false;
     }
-    if policy.mode == NetworkMode::Host {
-        return Vec::new();
+    let rules = String::from_utf8_lossy(&output.stdout);
+    rules.contains(&format!("iifname \"{veth_name}\" jump {chain_name}"))
+        && rules.contains(&format!("oifname \"{veth_name}\" jump {chain_name}"))
+}
+
+fn chain_has_jump(
+    output: &std::process::Output,
+    interface_match: &str,
+    veth_name: &str,
+    chain_name: &str,
+) -> bool {
+    output.status.success()
+        && String::from_utf8_lossy(&output.stdout).contains(&format!(
+            "{interface_match} \"{veth_name}\" jump {chain_name}"
+        ))
+}
+
+fn bridge_input_chain_rules(policy: &NetworkPolicy) -> Result<Vec<String>> {
+    if policy.mode != NetworkMode::Bridged {
+        return Ok(vec!["drop".into()]);
     }
 
-    let mut rules = vec!["ct state established,related accept".into()];
+    let mut rules = vec![
+        "ether type arp accept".into(),
+        "meta l4proto ipv6-icmp accept".into(),
+        "ct state established,related accept".into(),
+    ];
+    rules.extend(endpoint_rules("daddr", &policy.allowed_egress)?);
+    rules.push("drop".into());
+    Ok(rules)
+}
+
+fn bridge_output_chain_rules(policy: &NetworkPolicy) -> Result<Vec<String>> {
+    if policy.mode != NetworkMode::Bridged {
+        return Ok(vec!["drop".into()]);
+    }
+
+    let mut rules = vec![
+        "ether type arp accept".into(),
+        "meta l4proto ipv6-icmp accept".into(),
+        "ct state established,related accept".into(),
+    ];
+    rules.extend(endpoint_rules("saddr", &policy.allowed_ingress)?);
+    rules.push("drop".into());
+    Ok(rules)
+}
+
+fn bridge_zone_chain_rules(veth_name: &str, policy: &NetworkPolicy) -> Vec<String> {
+    if policy.mode != NetworkMode::Bridged {
+        return vec!["return".into()];
+    }
+
+    let mut rules = Vec::new();
     for zone in &policy.allowed_zones {
         let peer = super::network::veth_host_name_for(zone);
         rules.push(format!(
@@ -153,7 +269,6 @@ fn zone_chain_rules(veth_name: &str, policy: &NetworkPolicy) -> Vec<String> {
         ));
         rules.push(format!("iifname \"{peer}\" oifname \"{veth_name}\" accept"));
     }
-    rules.extend(egress_rules(veth_name, &policy.allowed_egress));
     rules.push("return".into());
     rules
 }
@@ -181,14 +296,14 @@ fn nft_chain_rules(output: &[u8], chain_name: &str) -> Vec<String> {
         .collect()
 }
 
-/// Remove rules in the forward chain that jump to the given zone chain.
-/// Uses nft handle-based deletion to avoid leaving stale rules.
-fn remove_forward_chain_jumps(chain_name: &str) -> Result<()> {
+/// Remove rules in a base chain that jump to the given zone chain.
+/// Uses nft handle-based deletion to avoid leaving stale references.
+fn remove_chain_jumps(family: &str, base_chain: &str, chain_name: &str) -> Result<()> {
     let output = Command::new("nft")
-        .args(["-a", "list", "chain", TABLE_FAMILY, TABLE_NAME, "forward"])
+        .args(["-a", "list", "chain", family, TABLE_NAME, base_chain])
         .output()
         .map_err(|e| RauhaError::NetworkError {
-            message: format!("failed to list nftables forward chain: {e}"),
+            message: format!("failed to list nftables {family} {base_chain} chain: {e}"),
             hint: "ensure nftables is installed (nft command)".into(),
         })?;
 
@@ -204,13 +319,7 @@ fn remove_forward_chain_jumps(chain_name: &str) -> Result<()> {
                 let handle = line[idx + "# handle ".len()..].trim();
                 if !handle.is_empty() {
                     let _ = run_nft(&[
-                        "delete",
-                        "rule",
-                        TABLE_FAMILY,
-                        TABLE_NAME,
-                        "forward",
-                        "handle",
-                        handle,
+                        "delete", "rule", family, TABLE_NAME, base_chain, "handle", handle,
                     ]);
                 }
             }
@@ -227,16 +336,38 @@ fn zone_chain_name(zone_name: &str) -> String {
     format!("zone-{zone_name}")
 }
 
-fn egress_rules(veth_name: &str, destinations: &[String]) -> Vec<String> {
-    destinations
+fn zone_input_chain_name(zone_name: &str) -> String {
+    format!("input-{zone_name}")
+}
+
+fn zone_output_chain_name(zone_name: &str) -> String {
+    format!("output-{zone_name}")
+}
+
+fn endpoint_rules(address_match: &str, targets: &[String]) -> Result<Vec<String>> {
+    targets
         .iter()
-        .map(|dest| format!("iifname \"{veth_name}\" ip daddr {dest} accept"))
+        .map(|target| {
+            let endpoint = target.parse::<NetworkEndpoint>().map_err(|error| {
+                RauhaError::InvalidPolicy(format!("invalid network target {target:?}: {error}"))
+            })?;
+            let mut rule = format!(
+                "{} {address_match} {}",
+                endpoint.nft_family(),
+                endpoint.network()
+            );
+            if let Some(port) = endpoint.port {
+                rule.push_str(&format!(" tcp dport {port}"));
+            }
+            rule.push_str(" accept");
+            Ok(rule)
+        })
         .collect()
 }
 
-fn table_exists() -> Result<bool> {
+fn table_exists(family: &str) -> Result<bool> {
     let output = Command::new("nft")
-        .args(["list", "table", TABLE_FAMILY, TABLE_NAME])
+        .args(["list", "table", family, TABLE_NAME])
         .output()
         .map_err(|e| RauhaError::NetworkError {
             message: format!("failed to check nftables table: {e}"),
@@ -316,30 +447,35 @@ mod tests {
     fn zone_chain_name_format() {
         assert_eq!(zone_chain_name("web"), "zone-web");
         assert_eq!(zone_chain_name("my-app"), "zone-my-app");
+        assert_eq!(zone_input_chain_name("web"), "input-web");
+        assert_eq!(zone_output_chain_name("web"), "output-web");
     }
 
     #[test]
     fn empty_egress_adds_no_implicit_dns_exception() {
-        assert!(egress_rules("veth-test", &[]).is_empty());
+        assert!(endpoint_rules("daddr", &[]).unwrap().is_empty());
     }
 
     #[test]
-    fn base_ruleset_replaces_atomically_with_default_drop() {
-        let rules = base_ruleset("10.89.0.0/16", true);
-        assert!(rules.starts_with("delete table inet rauha\nadd table inet rauha"));
-        assert!(rules.contains("policy drop"));
+    fn base_ruleset_replaces_both_tables_and_blocks_host_input() {
+        let rules = base_ruleset("10.89.0.0/16", true, true);
+        assert!(rules.starts_with(
+            "delete table inet rauha\ndelete table bridge rauha\nadd table inet rauha"
+        ));
+        assert!(rules.contains("add chain bridge rauha forward"));
+        assert!(rules.contains("add rule inet rauha input iifname \"rauha0\" drop"));
         assert!(rules.contains("ip saddr 10.89.0.0/16"));
     }
 
     #[test]
-    fn bridged_rules_are_bidirectional_and_fall_through_to_default_deny() {
+    fn bridge_rules_are_bidirectional_and_fall_through_to_default_deny() {
         let policy = NetworkPolicy {
             mode: NetworkMode::Bridged,
             allowed_zones: vec!["peer".into()],
             allowed_egress: vec![],
             allowed_ingress: vec![],
         };
-        let rules = zone_chain_rules("veth-source", &policy);
+        let rules = bridge_zone_chain_rules("veth-source", &policy);
         let peer_veth = super::super::network::veth_host_name_for("peer");
 
         assert_eq!(rules.last().unwrap(), "return");
@@ -349,6 +485,25 @@ mod tests {
         assert!(rules.contains(&format!(
             "iifname \"{peer_veth}\" oifname \"veth-source\" accept"
         )));
+    }
+
+    #[test]
+    fn endpoint_rules_support_ipv4_ipv6_and_tcp_ports() {
+        let rules =
+            endpoint_rules("daddr", &["10.0.0.0/8:443".into(), "2001:db8::/32".into()]).unwrap();
+        assert_eq!(
+            rules,
+            [
+                "ip daddr 10.0.0.0/8 tcp dport 443 accept",
+                "ip6 daddr 2001:db8::/32 accept",
+            ]
+        );
+    }
+
+    #[test]
+    fn endpoint_rules_reject_nft_injection() {
+        let error = endpoint_rules("daddr", &["0.0.0.0/0 accept".into()]).unwrap_err();
+        assert!(error.to_string().contains("invalid network target"));
     }
 
     #[test]

--- a/rauhad/src/main.rs
+++ b/rauhad/src/main.rs
@@ -118,6 +118,13 @@ async fn main() -> anyhow::Result<()> {
     registry.reconcile().await?;
 
     // Set up gRPC services.
+    let receipt_signer = rauha_evidence::receipt::ReceiptSigner::load_or_create(
+        &root_path.join("metadata").join("receipt.ed25519"),
+    )
+    .map_err(anyhow::Error::msg)?;
+    receipt_signer
+        .publish_public_key(&root_path.join("metadata").join("receipt.ed25519.pub"))
+        .map_err(anyhow::Error::msg)?;
     #[cfg(target_os = "linux")]
     let zone_svc = server::ZoneServiceImpl::new(registry.clone(), root.clone(), event_tx.clone());
     #[cfg(not(target_os = "linux"))]
@@ -125,9 +132,11 @@ async fn main() -> anyhow::Result<()> {
     let container_svc = server::ContainerServiceImpl::new(registry.clone());
     let image_svc = server::ImageServiceImpl::new(image_service);
     #[cfg(target_os = "linux")]
-    let sandbox_svc = server::SandboxServiceImpl::new(registry.clone(), event_tx.clone());
+    let sandbox_svc =
+        server::SandboxServiceImpl::new(registry.clone(), event_tx.clone(), receipt_signer.clone());
     #[cfg(not(target_os = "linux"))]
-    let sandbox_svc = server::SandboxServiceImpl::new(registry.clone(), None);
+    let sandbox_svc =
+        server::SandboxServiceImpl::new(registry.clone(), None, receipt_signer.clone());
 
     let addr: SocketAddr = "[::1]:9876".parse()?;
     tracing::info!(%addr, "listening on gRPC");

--- a/rauhad/src/server.rs
+++ b/rauhad/src/server.rs
@@ -5,6 +5,10 @@ use tonic::{Request, Response, Status, Streaming};
 use tracing::Instrument;
 
 use rauha_common::error::RauhaError;
+use rauha_evidence::receipt::{
+    enforcement_totals, sha256_json, ExecutionReceiptPayload, ImageAdmission, ReceiptSigner,
+    EXECUTION_RECEIPT_SCHEMA,
+};
 use rauha_evidence::{
     event_name, EnforcementMode, EventKind, EventOutcome, FalseEvent, FieldValue,
     RuntimeEventBuilder, Severity, TrustLevel,
@@ -39,6 +43,10 @@ fn to_status(e: RauhaError) -> Status {
 
         _ => Status::internal(e.to_string()),
     }
+}
+
+fn to_internal_status(error: impl std::fmt::Display) -> Status {
+    Status::internal(error.to_string())
 }
 
 pub mod pb {
@@ -1220,6 +1228,7 @@ pub struct SandboxServiceImpl {
     /// (macOS VMs, or Linux with eBPF not loaded), in which case sandbox
     /// results carry no enforcement events.
     event_tx: Option<tokio::sync::broadcast::Sender<FalseEvent>>,
+    receipt_signer: ReceiptSigner,
 }
 
 struct ContainerCleanupGuard {
@@ -1306,8 +1315,13 @@ impl SandboxServiceImpl {
     pub fn new(
         registry: Arc<ZoneRegistry>,
         event_tx: Option<tokio::sync::broadcast::Sender<rauha_evidence::FalseEvent>>,
+        receipt_signer: ReceiptSigner,
     ) -> Self {
-        Self { registry, event_tx }
+        Self {
+            registry,
+            event_tx,
+            receipt_signer,
+        }
     }
 
     /// Run one task to completion inside an already-resolved zone.
@@ -1571,7 +1585,7 @@ impl SandboxServiceImpl {
             SandboxStatus::Failed
         };
 
-        let enforcement_events = drain_enforcement_capture(capture);
+        let (enforcement_events, enforcement_drop_count) = drain_enforcement_capture(capture);
         sandbox_event_builder(
             &self.registry,
             event_name::SANDBOX_RESULT_BUILT,
@@ -1606,6 +1620,7 @@ impl SandboxServiceImpl {
             events,
             // Drain the events that landed on this task's zone while it ran.
             enforcement_events,
+            enforcement_drop_count,
         })
     }
 
@@ -1749,25 +1764,31 @@ struct EnforcementCapture {
 /// error means the broadcast outran our buffer; we keep draining what remains
 /// rather than aborting (some events are better than none, and the drop is
 /// already surfaced as a `pipeline.shed` event on the `WatchEvents` stream).
-fn drain_enforcement_capture(capture: Option<EnforcementCapture>) -> Vec<EnforcementEventSummary> {
+fn drain_enforcement_capture(
+    capture: Option<EnforcementCapture>,
+) -> (Vec<EnforcementEventSummary>, u64) {
     use tokio::sync::broadcast::error::TryRecvError;
 
     let Some(mut capture) = capture else {
-        return Vec::new();
+        return (Vec::new(), 0);
     };
 
     let mut out = Vec::new();
+    let mut dropped = 0;
     loop {
         match capture.rx.try_recv() {
             Ok(event) if enforcement_event_matches(&event, capture.kernel_zone_id) => {
                 out.push(project_enforcement_event(&event));
             }
             Ok(_) => {}
-            Err(TryRecvError::Lagged(_)) => continue,
+            Err(TryRecvError::Lagged(count)) => {
+                dropped += count;
+                continue;
+            }
             Err(TryRecvError::Empty | TryRecvError::Closed) => break,
         }
     }
-    out
+    (out, dropped)
 }
 
 /// Decide whether a broadcast enforcement event belongs to this task.
@@ -1857,6 +1878,7 @@ fn to_proto_result(
     exec: SandboxExecResult,
     admission: rauha_common::zone::PolicyAdmission,
     unavailable_controls: Vec<String>,
+    receipt_json: String,
 ) -> pb::sandbox::SandboxResult {
     pb::sandbox::SandboxResult {
         task_id: exec.task_id,
@@ -1895,6 +1917,7 @@ fn to_proto_result(
             .collect(),
         admission: admission_str(admission).into(),
         unavailable_controls,
+        receipt_json,
     }
 }
 
@@ -1959,7 +1982,7 @@ impl SandboxService for SandboxServiceImpl {
             // Resolve the zone. An empty name allocates a temporary zone that we own
             // and (by default) delete afterwards; a named zone must already exist
             // and is left intact.
-            let (zone_name, zone_id, temp_zone, admission) = if req.name.trim().is_empty() {
+            let (zone_name, zone_id, temp_zone, policy) = if req.name.trim().is_empty() {
                 let name = format!(
                     "sandbox-{}",
                     &uuid::Uuid::new_v4().simple().to_string()[..12]
@@ -1988,11 +2011,12 @@ impl SandboxService for SandboxServiceImpl {
                 )
                 .trust_level(TrustLevel::Complete)
                 .emit();
-                (zone.name, zone.id.to_string(), true, admission)
+                (zone.name, zone.id.to_string(), true, zone.policy)
             } else {
                 let zone = self.registry.get_zone(&req.name).await.map_err(to_status)?;
-                (zone.name, zone.id.to_string(), false, zone.policy.admission)
+                (zone.name, zone.id.to_string(), false, zone.policy)
             };
+            let admission = policy.admission;
             let mut zone_cleanup = (temp_zone && !req.keep_zone)
                 .then(|| ZoneCleanupGuard::new(self.registry.clone(), zone_name.clone()));
 
@@ -2081,6 +2105,51 @@ impl SandboxService for SandboxServiceImpl {
             let exec = outcome.unwrap_or_else(|message| {
                 SandboxExecResult::runtime_error(&task_id, &zone_id, req.command.clone(), message)
             });
+            let manifest_digest = self.registry.image_digest(&req.image).ok();
+            let receipt_env = req.env.iter().collect::<std::collections::BTreeMap<_, _>>();
+            let receipt = self.receipt_signer.sign(ExecutionReceiptPayload {
+                schema: EXECUTION_RECEIPT_SCHEMA.into(),
+                task_id: task_id.clone(),
+                zone_id: zone_id.clone(),
+                image: ImageAdmission {
+                    reference: req.image.clone(),
+                    manifest_digest: manifest_digest.clone().unwrap_or_default(),
+                    digest_verified: manifest_digest.is_some(),
+                },
+                policy_sha256: sha256_json(&policy).map_err(to_internal_status)?,
+                inputs_sha256: sha256_json(&serde_json::json!({
+                    "salt": task_id,
+                    "image": req.image,
+                    "command": req.command,
+                    "repo_path": req.repo_path,
+                    "workdir": req.workdir,
+                    "timeout_seconds": req.timeout_seconds,
+                    "env": receipt_env,
+                    "admission": admission_str(admission),
+                }))
+                .map_err(to_internal_status)?,
+                outputs_sha256: sha256_json(&serde_json::json!({
+                    "salt": task_id,
+                    "status": sandbox_status_str(exec.status),
+                    "exit_code": exec.exit_code,
+                    "stdout": exec.stdout,
+                    "stderr": exec.stderr,
+                }))
+                .map_err(to_internal_status)?,
+                status: sandbox_status_str(exec.status),
+                exit_code: exec.exit_code,
+                started_at: exec.started_at.map(|time| time.to_rfc3339()),
+                finished_at: exec.finished_at.map(|time| time.to_rfc3339()),
+                enforcement: enforcement_totals(
+                    exec.enforcement_events
+                        .iter()
+                        .map(|event| event.decision.as_str()),
+                    exec.enforcement_drop_count,
+                ),
+                unavailable_controls: unavailable_controls.clone(),
+            });
+            receipt.verify().map_err(to_internal_status)?;
+            let receipt_json = serde_json::to_string(&receipt).map_err(to_internal_status)?;
             let run_event = match exec.status {
                 SandboxStatus::Succeeded => (
                     event_name::SANDBOX_RUN_SUCCEEDED,
@@ -2134,6 +2203,7 @@ impl SandboxService for SandboxServiceImpl {
                 exec,
                 admission,
                 unavailable_controls,
+                receipt_json,
             )))
         }
         .instrument(span)
@@ -2189,6 +2259,7 @@ mod tests {
             exec,
             rauha_common::zone::PolicyAdmission::Audit,
             vec!["ebpf:test".into()],
+            "{}".into(),
         );
         assert_eq!(proto.status, "runtime_error");
         assert_eq!(proto.stderr, "boom");
@@ -2256,7 +2327,7 @@ mod tests {
 
     #[test]
     fn drain_without_capture_yields_no_events() {
-        assert!(drain_enforcement_capture(None).is_empty());
+        assert_eq!(drain_enforcement_capture(None), (Vec::new(), 0));
     }
 
     #[test]
@@ -2278,9 +2349,22 @@ mod tests {
             rx,
             kernel_zone_id: Some(7),
         };
-        let events = drain_enforcement_capture(Some(capture));
+        let (events, dropped) = drain_enforcement_capture(Some(capture));
 
+        assert_eq!(dropped, 0);
         assert_eq!(events.len(), 1, "only the task's own zone is captured");
         assert_eq!(events[0].source_zone.as_deref(), Some("zone-7"));
+    }
+
+    #[tokio::test]
+    async fn drain_counts_broadcast_lag() {
+        let (tx, rx) = tokio::sync::broadcast::channel(1);
+        tx.send(enforcement_event(7)).unwrap();
+        tx.send(enforcement_event(7)).unwrap();
+        let (_, dropped) = drain_enforcement_capture(Some(EnforcementCapture {
+            rx,
+            kernel_zone_id: Some(7),
+        }));
+        assert_eq!(dropped, 1);
     }
 }

--- a/rauhad/src/zone/registry.rs
+++ b/rauhad/src/zone/registry.rs
@@ -425,6 +425,12 @@ impl ZoneRegistry {
         self.metadata.list_zones()
     }
 
+    pub fn image_digest(&self, reference: &str) -> Result<String> {
+        self.image_service
+            .inspect_full(reference)
+            .map(|image| image.digest)
+    }
+
     pub async fn apply_policy(&self, zone_name: &str, policy: ZonePolicy) -> Result<()> {
         self.event(
             event_name::POLICY_APPLY_STARTED,

--- a/tests/integration/test-container-lifecycle.sh
+++ b/tests/integration/test-container-lifecycle.sh
@@ -79,6 +79,26 @@ $RAUHA stop "$CONTAINER_ID" || echo "   (may already be exited)"
 echo "10. Deleting container..."
 $RAUHA delete "$CONTAINER_ID" --force || echo "   (may already be deleted)"
 
+echo "10b. Stopping a sleeping workload (PID 1 of its namespace discards a default-disposition SIGTERM)..."
+STOP_CONTAINER_ID=$($RAUHA run --zone "$ZONE_NAME" "$IMAGE" /bin/sleep 120)
+sleep 1
+STOP_PID=$(head -n 1 "$CGROUP_PROCS")
+if [ -z "$STOP_CONTAINER_ID" ] || [ -z "$STOP_PID" ]; then
+    echo "FAIL: stop-probe workload was not enrolled in the zone cgroup"
+    exit 1
+fi
+STOP_START=$(awk '{print $22}' "/proc/$STOP_PID/stat")
+$RAUHA stop "$STOP_CONTAINER_ID"
+if [ -r "/proc/$STOP_PID/stat" ] && [ "$(awk '{print $22}' "/proc/$STOP_PID/stat")" = "$STOP_START" ]; then
+    echo "FAIL: stop returned while the workload was still running"
+    exit 1
+fi
+if $RAUHA ps --zone "$ZONE_NAME" | grep "$STOP_CONTAINER_ID" | grep -qi running; then
+    echo "FAIL: stopped container still reported as running"
+    exit 1
+fi
+$RAUHA delete "$STOP_CONTAINER_ID" --force
+
 echo "11. Starting a live workload for force-delete drain coverage..."
 LIVE_CONTAINER_ID=$($RAUHA run --zone "$ZONE_NAME" "$IMAGE" /bin/sleep 120)
 sleep 1

--- a/tests/integration/test-host-boundaries.sh
+++ b/tests/integration/test-host-boundaries.sh
@@ -9,7 +9,10 @@ NAME="boundary-$$"
 IMAGE=${TEST_IMAGE:-alpine:latest}
 HOSTNAME_BEFORE=$(hostname)
 POLICY_FILE=$(mktemp /tmp/rauha-host-boundaries-XXXXXX.toml)
+HARDENED_POLICY_FILE=$(mktemp /tmp/rauha-hardening-XXXXXX.toml)
+HARDENED_ZONE="$ZONE-policy"
 CONTAINER_ID=""
+HARDENED_CONTAINER_ID=""
 SENTINEL_PID=""
 FAILURES=0
 
@@ -27,8 +30,13 @@ cleanup() {
         $RAUHA stop "$CONTAINER_ID" 2>/dev/null || true
         $RAUHA delete "$CONTAINER_ID" --force 2>/dev/null || true
     fi
+    if [ -n "$HARDENED_CONTAINER_ID" ]; then
+        $RAUHA stop "$HARDENED_CONTAINER_ID" 2>/dev/null || true
+        $RAUHA delete "$HARDENED_CONTAINER_ID" --force 2>/dev/null || true
+    fi
     $RAUHA zone delete "$ZONE" --force 2>/dev/null || true
-    rm -f "$POLICY_FILE"
+    $RAUHA zone delete "$HARDENED_ZONE" --force 2>/dev/null || true
+    rm -f "$POLICY_FILE" "$HARDENED_POLICY_FILE"
     if [ "$(hostname)" != "$HOSTNAME_BEFORE" ]; then
         hostname "$HOSTNAME_BEFORE"
     fi
@@ -131,6 +139,29 @@ if $RAUHA sandbox --name "$ZONE" --image "$IMAGE" -- /bin/sh -c 'test ! -e /run/
 else
     fail "workload can access the zone cgroup enrollment handle"
 fi
+
+sed 's/mode = "strict"/mode = "audit"/' "$ROOT/policies/strict.toml" >"$HARDENED_POLICY_FILE"
+$RAUHA zone create --name "$HARDENED_ZONE" --policy "$HARDENED_POLICY_FILE" >/dev/null
+if $RAUHA sandbox --name "$HARDENED_ZONE" --image "$IMAGE" -- /bin/sh -c '
+    touch /tmp/allowed &&
+    ! touch /etc/denied &&
+    test -c /dev/null && test -c /dev/zero && test -c /dev/urandom &&
+    test ! -e /dev/kmsg &&
+    grep -Eq "^Seccomp:[[:space:]]+2$" /proc/self/status
+' >/dev/null 2>&1; then
+    echo "PASS: declared writable path, device allow-list, and seccomp deny profile applied"
+else
+    fail "OCI mount, device, or seccomp controls were not applied"
+fi
+HARDENED_CONTAINER_ID=$($RAUHA run --zone "$HARDENED_ZONE" "$IMAGE" /bin/sleep 30)
+if echo "" | $RAUHA exec -it "$HARDENED_CONTAINER_ID" /bin/true >/dev/null 2>&1; then
+    fail "interactive exec bypassed the container seccomp profile"
+else
+    echo "PASS: interactive exec fails closed for seccomp-filtered containers"
+fi
+$RAUHA stop "$HARDENED_CONTAINER_ID" >/dev/null
+$RAUHA delete "$HARDENED_CONTAINER_ID" --force >/dev/null
+HARDENED_CONTAINER_ID=""
 
 if $RAUHA sandbox --name "$ZONE" --image "$IMAGE" -- /bin/sh -c 'test "$$" -eq 1 && test "$(cat /proc/1/comm)" = sh' >/dev/null 2>&1; then
     echo "PASS: procfs exposes the container PID namespace"

--- a/tests/integration/test-host-boundaries.sh
+++ b/tests/integration/test-host-boundaries.sh
@@ -126,7 +126,7 @@ else
     echo "PASS: empty writable_paths makes the rootfs read-only"
 fi
 
-if $RAUHA sandbox --name "$ZONE" --image "$IMAGE" -- /bin/sh -c 'test -r /proc/1/status && test "$(cat /proc/1/comm)" = rauha-shim' >/dev/null 2>&1; then
+if $RAUHA sandbox --name "$ZONE" --image "$IMAGE" -- /bin/sh -c 'test "$$" -eq 1 && test "$(cat /proc/1/comm)" = sh' >/dev/null 2>&1; then
     echo "PASS: procfs exposes the container PID namespace"
 else
     fail "container procfs does not expose its PID 1"

--- a/tests/integration/test-host-boundaries.sh
+++ b/tests/integration/test-host-boundaries.sh
@@ -140,6 +140,12 @@ else
     fail "workload can access the zone cgroup enrollment handle"
 fi
 
+if $RAUHA sandbox --name "$ZONE" --image "$IMAGE" -- /bin/sh -c 'test ! -e /sys/fs/cgroup/rauha.slice && ! grep -q " cgroup2 " /proc/self/mounts' >/dev/null 2>&1; then
+    echo "PASS: host cgroup hierarchy is not visible to the workload"
+else
+    fail "workload can enumerate the host cgroup hierarchy"
+fi
+
 sed 's/mode = "strict"/mode = "audit"/' "$ROOT/policies/strict.toml" >"$HARDENED_POLICY_FILE"
 $RAUHA zone create --name "$HARDENED_ZONE" --policy "$HARDENED_POLICY_FILE" >/dev/null
 if $RAUHA sandbox --name "$HARDENED_ZONE" --image "$IMAGE" -- /bin/sh -c '

--- a/tests/integration/test-host-boundaries.sh
+++ b/tests/integration/test-host-boundaries.sh
@@ -126,6 +126,12 @@ else
     echo "PASS: empty writable_paths makes the rootfs read-only"
 fi
 
+if $RAUHA sandbox --name "$ZONE" --image "$IMAGE" -- /bin/sh -c 'test ! -e /run/rauha-zone.procs' >/dev/null 2>&1; then
+    echo "PASS: workload has no writable cgroup enrollment handle"
+else
+    fail "workload can access the zone cgroup enrollment handle"
+fi
+
 if $RAUHA sandbox --name "$ZONE" --image "$IMAGE" -- /bin/sh -c 'test "$$" -eq 1 && test "$(cat /proc/1/comm)" = sh' >/dev/null 2>&1; then
     echo "PASS: procfs exposes the container PID namespace"
 else

--- a/tests/integration/test-sandbox.sh
+++ b/tests/integration/test-sandbox.sh
@@ -12,10 +12,12 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 AUDIT_POLICY=${RAUHA_TEST_AUDIT_POLICY:-$ROOT/policies/audit.toml}
 IMAGE="${TEST_IMAGE:-alpine:latest}"
 NAMED_ZONE="test-sandbox-$$"
+RECEIPT_FILE=$(mktemp /tmp/rauha-receipt-XXXXXX.json)
 
 cleanup() {
     echo "Cleaning up..."
     $RAUHA zone delete "$NAMED_ZONE" --force 2>/dev/null || true
+    rm -f "$RECEIPT_FILE"
 }
 trap cleanup EXIT
 
@@ -57,14 +59,21 @@ echo "5. JSON output reports a succeeded status..."
 JSON=$($RAUHA --json sandbox --audit --image "$IMAGE" -- /bin/echo hi)
 if echo "$JSON" | grep -q '"status":"succeeded"' \
     && echo "$JSON" | grep -q '"exit_code":0' \
-    && echo "$JSON" | grep -q '"admission":"audit"'; then
+    && echo "$JSON" | grep -q '"admission":"audit"' \
+    && echo "$JSON" | grep -q '"schema":"rauha.execution-receipt.v1"' \
+    && echo "$JSON" | grep -q '"digest_verified":true'; then
     echo "   JSON contract intact (OK)"
 else
     echo "   FAIL: unexpected JSON result: $JSON"
     exit 1
 fi
 
-echo "6. A named, pre-existing zone is reused and left intact..."
+echo "6. The execution receipt verifies independently..."
+printf '%s\n' "$JSON" >"$RECEIPT_FILE"
+$RAUHA receipt "$RECEIPT_FILE" --public-key "${RAUHA_ROOT:?}/metadata/receipt.ed25519.pub" >/dev/null
+echo "   signed receipt verified (OK)"
+
+echo "7. A named, pre-existing zone is reused and left intact..."
 $RAUHA zone create --name "$NAMED_ZONE" --policy "$AUDIT_POLICY"
 $RAUHA sandbox --image "$IMAGE" --name "$NAMED_ZONE" -- /bin/echo in-named-zone >/dev/null
 if $RAUHA zone list 2>/dev/null | grep -q "$NAMED_ZONE"; then

--- a/tests/integration/test-zone-networking.sh
+++ b/tests/integration/test-zone-networking.sh
@@ -6,11 +6,16 @@ set -euo pipefail
 RAUHA="${RAUHA_BIN:-cargo run --bin rauha --}"
 ZONE_A="test-net-a-$$"
 ZONE_B="test-net-b-$$"
+ZONE_C="test-net-c-$$"
 IMAGE="${TEST_IMAGE:-alpine:latest}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOST_SERVER_PID=""
+HOST_PORT=$((20000 + $$ % 20000))
+HOST_LOG=$(mktemp /tmp/rauha-host-http-XXXXXX.log)
 
 # Create a temporary bridged policy that allows cross-zone and internet.
 POLICY_FILE=$(mktemp /tmp/rauha-test-net-XXXXXX.toml)
+DENY_POLICY_FILE=$(mktemp /tmp/rauha-test-net-deny-XXXXXX.toml)
 cat > "$POLICY_FILE" <<TOML
 [zone]
 name = "placeholder"
@@ -19,17 +24,40 @@ type = "non-global"
 [admission]
 mode = "audit"
 
+[capabilities]
+allowed = ["CAP_NET_RAW"]
+
 [network]
 mode = "bridged"
 allowed_zones = ["$ZONE_A", "$ZONE_B"]
 allowed_egress = ["0.0.0.0/0"]
 TOML
+cat > "$DENY_POLICY_FILE" <<TOML
+[zone]
+name = "placeholder"
+type = "non-global"
+
+[admission]
+mode = "audit"
+
+[capabilities]
+allowed = ["CAP_NET_RAW"]
+
+[network]
+mode = "bridged"
+allowed_zones = []
+allowed_egress = []
+allowed_ingress = []
+TOML
 
 cleanup() {
     echo "Cleaning up..."
+    [ -z "$HOST_SERVER_PID" ] || kill "$HOST_SERVER_PID" 2>/dev/null || true
     $RAUHA zone delete "$ZONE_A" --force 2>/dev/null || true
     $RAUHA zone delete "$ZONE_B" --force 2>/dev/null || true
-    rm -f "$POLICY_FILE"
+    $RAUHA zone delete "$ZONE_C" --force 2>/dev/null || true
+    ip -6 addr del fd89::1/64 dev rauha0 2>/dev/null || true
+    rm -f "$POLICY_FILE" "$DENY_POLICY_FILE" "$HOST_LOG"
 }
 trap cleanup EXIT
 
@@ -44,7 +72,10 @@ $RAUHA zone create --name "$ZONE_A" --policy "$POLICY_FILE"
 echo "3. Creating zone B (bridged)..."
 $RAUHA zone create --name "$ZONE_B" --policy "$POLICY_FILE"
 
-echo "4. Checking bridge has gateway IP..."
+echo "4. Creating zone C (bridged, no peers or egress)..."
+$RAUHA zone create --name "$ZONE_C" --policy "$DENY_POLICY_FILE"
+
+echo "5. Checking bridge has gateway IP..."
 if ip addr show rauha0 | grep -q "10.89.0.1"; then
     echo "   rauha0 gateway: 10.89.0.1 (OK)"
 else
@@ -52,7 +83,7 @@ else
     exit 1
 fi
 
-echo "5. Checking IP forwarding is enabled..."
+echo "6. Checking IP forwarding is enabled..."
 if [ "$(cat /proc/sys/net/ipv4/ip_forward)" = "1" ]; then
     echo "   ip_forward: enabled (OK)"
 else
@@ -60,30 +91,72 @@ else
     exit 1
 fi
 
-echo "6. Checking nftables NAT table exists..."
+echo "7. Checking inet and bridge nftables boundaries exist..."
 if nft list table inet rauha 2>/dev/null | grep "masquerade" >/dev/null; then
     echo "   nftables masquerade: present (OK)"
 else
     echo "   FAIL: nftables masquerade rule not found"
     exit 1
 fi
+if nft list table bridge rauha 2>/dev/null | grep "policy drop" >/dev/null; then
+    echo "   bridge default drop: present (OK)"
+else
+    echo "   FAIL: bridge default-drop boundary not found"
+    exit 1
+fi
 
-echo "7. Testing internet connectivity from zone A..."
-$RAUHA run --zone "$ZONE_A" "$IMAGE" /bin/ping -c1 -W5 8.8.8.8
+echo "8. Testing internet connectivity from zone A..."
+$RAUHA sandbox --name "$ZONE_A" --image "$IMAGE" -- /bin/ping -c1 -W5 8.8.8.8
 echo "   Internet ping from zone A: OK"
 
-echo "8. Getting zone IPs from namespaces..."
+echo "9. Getting zone IPs from namespaces..."
 ZONE_A_IP=$(ip netns exec "rauha-${ZONE_A}" ip -4 addr show eth0 | awk '/inet / {print $2}' | cut -d/ -f1)
 ZONE_B_IP=$(ip netns exec "rauha-${ZONE_B}" ip -4 addr show eth0 | awk '/inet / {print $2}' | cut -d/ -f1)
+ZONE_C_IP=$(ip netns exec "rauha-${ZONE_C}" ip -4 addr show eth0 | awk '/inet / {print $2}' | cut -d/ -f1)
 echo "   Zone A IP: $ZONE_A_IP"
 echo "   Zone B IP: $ZONE_B_IP"
+echo "   Zone C IP: $ZONE_C_IP"
 
-echo "9. Testing cross-zone connectivity (A → B)..."
-$RAUHA run --zone "$ZONE_A" "$IMAGE" /bin/ping -c1 -W5 "$ZONE_B_IP"
+echo "10. Testing explicitly allowed cross-zone connectivity (A → B)..."
+$RAUHA sandbox --name "$ZONE_A" --image "$IMAGE" -- /bin/ping -c1 -W5 "$ZONE_B_IP"
 echo "   Cross-zone ping A → B: OK"
 
-echo "10. Testing DNS resolution from zone A..."
-$RAUHA run --zone "$ZONE_A" "$IMAGE" /bin/sh -c "cat /etc/resolv.conf"
+echo "11. Testing bridge default-deny connectivity (A → C)..."
+if $RAUHA sandbox --name "$ZONE_A" --image "$IMAGE" -- /bin/ping -c1 -W2 "$ZONE_C_IP" >/dev/null 2>&1; then
+    echo "   FAIL: undeclared cross-zone IPv4 traffic reached zone C"
+    exit 1
+else
+    echo "   Undeclared cross-zone IPv4 traffic: denied (OK)"
+fi
+
+echo "12. Testing zone-to-host service denial..."
+python3 -m http.server "$HOST_PORT" --bind 10.89.0.1 >"$HOST_LOG" 2>&1 &
+HOST_SERVER_PID=$!
+sleep 0.2
+if $RAUHA sandbox --name "$ZONE_A" --image "$IMAGE" -- /bin/sh -c \
+    "wget -q -T 2 -O- http://10.89.0.1:$HOST_PORT" >/dev/null 2>&1; then
+    echo "   FAIL: zone reached an undeclared host-local service"
+    exit 1
+else
+    echo "   Undeclared host-local IPv4 service: denied (OK)"
+fi
+
+echo "13. Testing IPv6 host and cross-zone denial..."
+ip -6 addr add fd89::1/64 dev rauha0
+ip netns exec "rauha-${ZONE_A}" ip -6 addr add fd89::a/64 dev eth0
+ip netns exec "rauha-${ZONE_C}" ip -6 addr add fd89::c/64 dev eth0
+if $RAUHA sandbox --name "$ZONE_A" --image "$IMAGE" -- /bin/ping -6 -c1 -W2 fd89::1 >/dev/null 2>&1; then
+    echo "   FAIL: zone reached the host over IPv6"
+    exit 1
+fi
+if $RAUHA sandbox --name "$ZONE_A" --image "$IMAGE" -- /bin/ping -6 -c1 -W2 fd89::c >/dev/null 2>&1; then
+    echo "   FAIL: undeclared cross-zone IPv6 traffic reached zone C"
+    exit 1
+fi
+echo "   Undeclared IPv6 host and cross-zone traffic: denied (OK)"
+
+echo "14. Testing DNS configuration from zone A..."
+$RAUHA sandbox --name "$ZONE_A" --image "$IMAGE" -- /bin/sh -c "cat /etc/resolv.conf"
 echo "    resolv.conf present: OK"
 
 echo ""

--- a/tests/integration/test-zone-networking.sh
+++ b/tests/integration/test-zone-networking.sh
@@ -61,7 +61,7 @@ else
 fi
 
 echo "6. Checking nftables NAT table exists..."
-if nft list table inet rauha 2>/dev/null | grep -q "masquerade"; then
+if nft list table inet rauha 2>/dev/null | grep "masquerade" >/dev/null; then
     echo "   nftables masquerade: present (OK)"
 else
     echo "   FAIL: nftables masquerade rule not found"

--- a/tests/security/linux-gate.sh
+++ b/tests/security/linux-gate.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 cd "$ROOT"
 export RAUHA_ADDR='http://[::1]:9876'
+TEST_IMAGE=${TEST_IMAGE:-alpine:latest}
+TEST_SECONDARY_IMAGE=${TEST_SECONDARY_IMAGE:-busybox:latest}
 
 [ "$(uname -s)" = Linux ] || { echo "Linux is required" >&2; exit 2; }
 test -r /sys/kernel/btf/vmlinux || { echo "kernel BTF is required" >&2; exit 2; }
@@ -96,7 +98,7 @@ start_daemon
 FAILURES=0
 TEST_TIMEOUT=${RAUHA_TEST_TIMEOUT_SECONDS:-120}
 for test_script in tests/integration/*.sh; do
-    if ! sudo env RAUHA_ADDR="$RAUHA_ADDR" RAUHA_BIN="$ROOT/target/debug/rauha" RAUHA_ROOT="$RUN_ROOT" \
+    if ! sudo env RAUHA_ADDR="$RAUHA_ADDR" RAUHA_BIN="$ROOT/target/debug/rauha" RAUHA_ROOT="$RUN_ROOT" TEST_IMAGE="$TEST_IMAGE" \
         timeout --foreground --kill-after=5s "$TEST_TIMEOUT" bash "$test_script"; then
         echo "FAILED: $test_script" >&2
         FAILURES=$((FAILURES + 1))
@@ -105,19 +107,19 @@ done
 
 # Prove crash recovery against live kernel state, not only serialized metadata.
 RECOVERY_STATE="$RUN_ROOT/recovery-probe.state"
-sudo env RAUHA_ADDR="$RAUHA_ADDR" RAUHA_BIN="$ROOT/target/debug/rauha" RAUHA_ROOT="$RUN_ROOT" \
+sudo env RAUHA_ADDR="$RAUHA_ADDR" RAUHA_BIN="$ROOT/target/debug/rauha" RAUHA_ROOT="$RUN_ROOT" TEST_IMAGE="$TEST_IMAGE" \
     bash "$ROOT/tests/security/recovery-probe.sh" prepare "$RECOVERY_STATE"
 crash_daemon
 start_daemon
-sudo env RAUHA_ADDR="$RAUHA_ADDR" RAUHA_BIN="$ROOT/target/debug/rauha" RAUHA_ROOT="$RUN_ROOT" \
+sudo env RAUHA_ADDR="$RAUHA_ADDR" RAUHA_BIN="$ROOT/target/debug/rauha" RAUHA_ROOT="$RUN_ROOT" TEST_IMAGE="$TEST_IMAGE" \
     bash "$ROOT/tests/security/recovery-probe.sh" verify "$RECOVERY_STATE"
 
-# Exercise a mature OCI executor against a Rauha-prepared rootfs and the
-# existing zone cgroup/netns boundary without changing the production path.
-sudo env RAUHA_ADDR="$RAUHA_ADDR" RAUHA_BIN="$ROOT/target/debug/rauha" RAUHA_ROOT="$RUN_ROOT" \
+# Prove the production two-phase OCI handoff against a Rauha-prepared rootfs.
+sudo env RAUHA_ADDR="$RAUHA_ADDR" RAUHA_BIN="$ROOT/target/debug/rauha" RAUHA_ROOT="$RUN_ROOT" TEST_IMAGE="$TEST_IMAGE" \
     bash "$ROOT/tests/security/oci-executor-probe.sh"
 
 if ! timeout --foreground --kill-after=5s "$TEST_TIMEOUT" env RAUHA_GRPC_ENDPOINT=http://[::1]:9876 \
+    TEST_IMAGE="$TEST_IMAGE" TEST_SECONDARY_IMAGE="$TEST_SECONDARY_IMAGE" \
     cargo test --quiet --manifest-path eval/oracle/Cargo.toml --locked; then
     echo "FAILED: eval/oracle" >&2
     FAILURES=$((FAILURES + 1))

--- a/tests/security/linux-gate.sh
+++ b/tests/security/linux-gate.sh
@@ -9,7 +9,7 @@ export RAUHA_ADDR='http://[::1]:9876'
 [ "$(uname -s)" = Linux ] || { echo "Linux is required" >&2; exit 2; }
 test -r /sys/kernel/btf/vmlinux || { echo "kernel BTF is required" >&2; exit 2; }
 grep -qw bpf /sys/kernel/security/lsm || { echo "BPF LSM is required" >&2; exit 2; }
-for command in cargo bpf-linker findmnt ip nft pgrep protoc rustup sudo timeout; do
+for command in cargo bpf-linker crun findmnt ip jq nft pgrep protoc rustup sudo timeout; do
     command -v "$command" >/dev/null || { echo "$command is required" >&2; exit 2; }
 done
 
@@ -21,14 +21,53 @@ cargo xtask build-ebpf --release
 
 RUN_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/rauha-security.XXXXXX")
 DAEMON_LOG="$ROOT/.sykli/rauhad.log"
+DAEMON_PID_FILE="$RUN_ROOT/rauhad.pid"
 HOSTNAME_BEFORE=$(hostname)
 mkdir -p "$ROOT/.sykli"
 DAEMON_PID=""
+DAEMON_LAUNCH_PID=""
+
+start_daemon() {
+    sudo env RAUHA_ROOT="$RUN_ROOT" RAUHA_PID_FILE="$DAEMON_PID_FILE" \
+        sh -c 'printf "%s\n" "$$" >"$RAUHA_PID_FILE"; exec "$1"' \
+        sh "$ROOT/target/debug/rauhad" >>"$DAEMON_LOG" 2>&1 &
+    DAEMON_LAUNCH_PID=$!
+
+    for _ in $(seq 1 30); do
+        [ -s "$DAEMON_PID_FILE" ] && break
+        sleep 0.1
+    done
+    DAEMON_PID=$(cat "$DAEMON_PID_FILE" 2>/dev/null || true)
+    [ -n "$DAEMON_PID" ] || { echo "rauhad did not publish its PID" >&2; return 1; }
+
+    for _ in $(seq 1 30); do
+        if ! sudo kill -0 "$DAEMON_PID" 2>/dev/null; then
+            wait "$DAEMON_LAUNCH_PID" 2>/dev/null || true
+            tail -100 "$DAEMON_LOG" >&2
+            echo "rauhad exited before becoming ready" >&2
+            return 1
+        fi
+        if "$ROOT/target/debug/rauha" zone list >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    tail -100 "$DAEMON_LOG" >&2
+    return 1
+}
+
+crash_daemon() {
+    sudo kill -KILL "$DAEMON_PID"
+    wait "$DAEMON_LAUNCH_PID" 2>/dev/null || true
+    DAEMON_PID=""
+    DAEMON_LAUNCH_PID=""
+    rm -f "$DAEMON_PID_FILE"
+}
 
 cleanup() {
     if [ -n "$DAEMON_PID" ]; then
         sudo kill "$DAEMON_PID" 2>/dev/null || true
-        wait "$DAEMON_PID" 2>/dev/null || true
+        wait "$DAEMON_LAUNCH_PID" 2>/dev/null || true
     fi
     while read -r shim_pid; do
         sudo kill "$shim_pid" 2>/dev/null || true
@@ -51,27 +90,8 @@ if "$ROOT/target/debug/rauha" zone list >/dev/null 2>&1; then
     exit 2
 fi
 
-sudo env RAUHA_ROOT="$RUN_ROOT" "$ROOT/target/debug/rauhad" >"$DAEMON_LOG" 2>&1 &
-DAEMON_PID=$!
-
-READY=false
-for _ in $(seq 1 30); do
-    if ! sudo kill -0 "$DAEMON_PID" 2>/dev/null; then
-        wait "$DAEMON_PID" 2>/dev/null || true
-        tail -100 "$DAEMON_LOG" >&2
-        echo "rauhad exited before becoming ready" >&2
-        exit 1
-    fi
-    if "$ROOT/target/debug/rauha" zone list >/dev/null 2>&1; then
-        READY=true
-        break
-    fi
-    sleep 1
-done
-if [ "$READY" != true ]; then
-    tail -100 "$DAEMON_LOG" >&2
-    exit 1
-fi
+: >"$DAEMON_LOG"
+start_daemon
 
 FAILURES=0
 TEST_TIMEOUT=${RAUHA_TEST_TIMEOUT_SECONDS:-120}
@@ -82,6 +102,20 @@ for test_script in tests/integration/*.sh; do
         FAILURES=$((FAILURES + 1))
     fi
 done
+
+# Prove crash recovery against live kernel state, not only serialized metadata.
+RECOVERY_STATE="$RUN_ROOT/recovery-probe.state"
+sudo env RAUHA_ADDR="$RAUHA_ADDR" RAUHA_BIN="$ROOT/target/debug/rauha" RAUHA_ROOT="$RUN_ROOT" \
+    bash "$ROOT/tests/security/recovery-probe.sh" prepare "$RECOVERY_STATE"
+crash_daemon
+start_daemon
+sudo env RAUHA_ADDR="$RAUHA_ADDR" RAUHA_BIN="$ROOT/target/debug/rauha" RAUHA_ROOT="$RUN_ROOT" \
+    bash "$ROOT/tests/security/recovery-probe.sh" verify "$RECOVERY_STATE"
+
+# Exercise a mature OCI executor against a Rauha-prepared rootfs and the
+# existing zone cgroup/netns boundary without changing the production path.
+sudo env RAUHA_ADDR="$RAUHA_ADDR" RAUHA_BIN="$ROOT/target/debug/rauha" RAUHA_ROOT="$RUN_ROOT" \
+    bash "$ROOT/tests/security/oci-executor-probe.sh"
 
 if ! timeout --foreground --kill-after=5s "$TEST_TIMEOUT" env RAUHA_GRPC_ENDPOINT=http://[::1]:9876 \
     cargo test --quiet --manifest-path eval/oracle/Cargo.toml --locked; then

--- a/tests/security/linux-gate.sh
+++ b/tests/security/linux-gate.sh
@@ -9,7 +9,7 @@ export RAUHA_ADDR='http://[::1]:9876'
 [ "$(uname -s)" = Linux ] || { echo "Linux is required" >&2; exit 2; }
 test -r /sys/kernel/btf/vmlinux || { echo "kernel BTF is required" >&2; exit 2; }
 grep -qw bpf /sys/kernel/security/lsm || { echo "BPF LSM is required" >&2; exit 2; }
-for command in cargo bpf-linker crun findmnt ip jq nft pgrep protoc rustup sudo timeout; do
+for command in cargo bpf-linker crun findmnt ip jq nft pgrep protoc python3 rustup sudo timeout; do
     command -v "$command" >/dev/null || { echo "$command is required" >&2; exit 2; }
 done
 

--- a/tests/security/oci-executor-probe.sh
+++ b/tests/security/oci-executor-probe.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Prove crun can consume a Rauha-prepared rootfs while preserving Rauha's
+# exact cgroup and network-namespace boundary used by the production executor.
+set -euo pipefail
+
+RAUHA=${RAUHA_BIN:?RAUHA_BIN is required}
+RAUHA_ROOT=${RAUHA_ROOT:?RAUHA_ROOT is required}
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+POLICY=${RAUHA_TEST_AUDIT_POLICY:-$ROOT/policies/audit.toml}
+IMAGE=${TEST_IMAGE:-alpine:latest}
+ZONE="test-oci-executor-$$"
+BUNDLE=$(mktemp -d "$RAUHA_ROOT/oci-executor.XXXXXX")
+RUNTIME_ROOT="$BUNDLE/runtime"
+CGROUP="/sys/fs/cgroup/rauha.slice/zone-$ZONE"
+ROOTFS_MOUNTED=false
+
+cleanup() {
+    for id in "probe-$ZONE" "probe-$ZONE-1" "probe-$ZONE-2" "probe-$ZONE-3" "probe-$ZONE-4" "probe-$ZONE-5"; do
+        crun --root "$RUNTIME_ROOT" --cgroup-manager=disabled delete --force "$id" >/dev/null 2>&1 || true
+    done
+    if [ "$ROOTFS_MOUNTED" = true ]; then
+        umount "$BUNDLE/rootfs" >/dev/null 2>&1 || true
+    fi
+    "$RAUHA" zone delete "$ZONE" --force >/dev/null 2>&1 || true
+    case "$BUNDLE" in
+        "$RAUHA_ROOT"/oci-executor.*) rm -rf -- "$BUNDLE" ;;
+        *) echo "refusing to remove unexpected bundle path: $BUNDLE" >&2 ;;
+    esac
+}
+trap cleanup EXIT
+
+"$RAUHA" image pull "$IMAGE" >/dev/null
+"$RAUHA" zone create --name "$ZONE" --policy "$POLICY" >/dev/null
+CONTAINER=$($RAUHA run --zone "$ZONE" "$IMAGE" /bin/true)
+CONTAINER_DIR="$RAUHA_ROOT/zones/$ZONE/containers/$CONTAINER"
+if [ -d "$CONTAINER_DIR/merged" ]; then
+    ROOTFS="$CONTAINER_DIR/merged"
+elif [ -d "$CONTAINER_DIR/rootfs" ]; then
+    ROOTFS="$CONTAINER_DIR/rootfs"
+else
+    echo "Rauha did not prepare an OCI rootfs for $CONTAINER" >&2
+    exit 1
+fi
+
+mkdir -p "$RUNTIME_ROOT"
+mkdir "$BUNDLE/rootfs"
+mount --bind "$ROOTFS" "$BUNDLE/rootfs"
+ROOTFS_MOUNTED=true
+HOST_NETNS=$(readlink /proc/self/ns/net)
+jq -n \
+    --arg hostname "crun-$ZONE" \
+    --arg netns "/var/run/netns/rauha-$ZONE" \
+    --arg cgroup_procs "$CGROUP/cgroup.procs" \
+    '{
+        ociVersion: "1.0.2",
+        process: {
+            terminal: false,
+            user: {uid: 0, gid: 0},
+            args: ["/bin/sh", "-c", "hostname; grep -E \"^(CapEff|NoNewPrivs):\" /proc/self/status; readlink /proc/self/ns/net; cat /proc/self/cgroup"],
+            env: ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],
+            cwd: "/",
+            capabilities: {bounding: [], effective: [], inheritable: [], permitted: [], ambient: []},
+            noNewPrivileges: true
+        },
+        root: {path: "rootfs", readonly: true},
+        hostname: $hostname,
+        mounts: [
+            {destination: "/proc", type: "proc", source: "proc", options: ["nosuid", "noexec", "nodev"]},
+            {destination: "/run/rauha-zone.procs", type: "bind", source: $cgroup_procs, options: ["bind", "rw", "nosuid", "noexec", "nodev"]}
+        ],
+        hooks: {
+            startContainer: [{
+                path: "/bin/sh",
+                args: ["sh", "-c", "printf 1 > /run/rauha-zone.procs"],
+                env: ["PATH=/usr/sbin:/usr/bin:/sbin:/bin"]
+            }]
+        },
+        linux: {
+            namespaces: [
+                {type: "pid"},
+                {type: "mount"},
+                {type: "uts"},
+                {type: "ipc"},
+                {type: "network", path: $netns}
+            ]
+        }
+    }' >"$BUNDLE/config.json"
+
+OUTPUT=$(crun --root "$RUNTIME_ROOT" --cgroup-manager=disabled run --bundle "$BUNDLE" "probe-$ZONE")
+printf '%s\n' "$OUTPUT" | grep -qx "crun-$ZONE"
+printf '%s\n' "$OUTPUT" | grep -Eq '^CapEff:[[:space:]]+0+$'
+printf '%s\n' "$OUTPUT" | grep -Eq '^NoNewPrivs:[[:space:]]+1$'
+CONTAINER_NETNS=$(printf '%s\n' "$OUTPUT" | grep '^net:\[')
+[ "$CONTAINER_NETNS" != "$HOST_NETNS" ] || { echo "crun workload remained in the host netns" >&2; exit 1; }
+printf '%s\n' "$OUTPUT" | grep -Fq "/rauha.slice/zone-$ZONE"
+"$RAUHA" --json zone verify "$ZONE" | jq -e '
+    .checks[] | select(.name == "bpf_membership" and .passed == true)
+' >/dev/null
+
+START=$(date +%s%N)
+for iteration in 1 2 3 4 5; do
+    crun --root "$RUNTIME_ROOT" --cgroup-manager=disabled run --bundle "$BUNDLE" \
+        "probe-$ZONE-$iteration" >/dev/null
+done
+END=$(date +%s%N)
+AVERAGE_MS=$(((END - START) / 5000000))
+echo "PASS: crun preserved Rauha cgroup/netns/security state; warm bundle launch average ${AVERAGE_MS}ms (n=5)"

--- a/tests/security/oci-executor-probe.sh
+++ b/tests/security/oci-executor-probe.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Prove crun can consume a Rauha-prepared rootfs while preserving Rauha's
-# exact cgroup and network-namespace boundary used by the production executor.
+# Prove the production handoff: crun creates a blocked init, trusted host code
+# enrolls it in the exact zone cgroup, then crun releases the workload.
 set -euo pipefail
 
 RAUHA=${RAUHA_BIN:?RAUHA_BIN is required}
@@ -50,7 +50,6 @@ HOST_NETNS=$(readlink /proc/self/ns/net)
 jq -n \
     --arg hostname "crun-$ZONE" \
     --arg netns "/var/run/netns/rauha-$ZONE" \
-    --arg cgroup_procs "$CGROUP/cgroup.procs" \
     '{
         ociVersion: "1.0.2",
         process: {
@@ -65,16 +64,8 @@ jq -n \
         root: {path: "rootfs", readonly: true},
         hostname: $hostname,
         mounts: [
-            {destination: "/proc", type: "proc", source: "proc", options: ["nosuid", "noexec", "nodev"]},
-            {destination: "/run/rauha-zone.procs", type: "bind", source: $cgroup_procs, options: ["bind", "rw", "nosuid", "noexec", "nodev"]}
+            {destination: "/proc", type: "proc", source: "proc", options: ["nosuid", "noexec", "nodev"]}
         ],
-        hooks: {
-            startContainer: [{
-                path: "/bin/sh",
-                args: ["sh", "-c", "printf 1 > /run/rauha-zone.procs"],
-                env: ["PATH=/usr/sbin:/usr/bin:/sbin:/bin"]
-            }]
-        },
         linux: {
             namespaces: [
                 {type: "pid"},
@@ -86,7 +77,27 @@ jq -n \
         }
     }' >"$BUNDLE/config.json"
 
-OUTPUT=$(crun --root "$RUNTIME_ROOT" --cgroup-manager=disabled run --bundle "$BUNDLE" "probe-$ZONE")
+run_probe() {
+    local id=$1 output=$2 pid status
+    : >"$output"
+    crun --root "$RUNTIME_ROOT" --cgroup-manager=disabled create --bundle "$BUNDLE" \
+        --pid-file "$BUNDLE/$id.pid" "$id" >"$output"
+    pid=$(cat "$BUNDLE/$id.pid")
+    [ ! -s "$output" ] || { echo "workload ran before cgroup enrollment" >&2; exit 1; }
+    printf '%s' "$pid" >"$CGROUP/cgroup.procs"
+    grep -Fq "/rauha.slice/zone-$ZONE" "/proc/$pid/cgroup"
+    crun --root "$RUNTIME_ROOT" --cgroup-manager=disabled start "$id"
+    for _ in $(seq 1 500); do
+        status=$(crun --root "$RUNTIME_ROOT" --cgroup-manager=disabled state "$id" 2>/dev/null | jq -r .status || true)
+        [ "$status" = stopped ] && break
+        sleep 0.01
+    done
+    [ "$status" = stopped ] || { echo "crun workload did not stop" >&2; exit 1; }
+    crun --root "$RUNTIME_ROOT" --cgroup-manager=disabled delete "$id"
+}
+
+run_probe "probe-$ZONE" "$BUNDLE/output"
+OUTPUT=$(cat "$BUNDLE/output")
 printf '%s\n' "$OUTPUT" | grep -qx "crun-$ZONE"
 printf '%s\n' "$OUTPUT" | grep -Eq '^CapEff:[[:space:]]+0+$'
 printf '%s\n' "$OUTPUT" | grep -Eq '^NoNewPrivs:[[:space:]]+1$'
@@ -99,9 +110,8 @@ printf '%s\n' "$OUTPUT" | grep -Fq "/rauha.slice/zone-$ZONE"
 
 START=$(date +%s%N)
 for iteration in 1 2 3 4 5; do
-    crun --root "$RUNTIME_ROOT" --cgroup-manager=disabled run --bundle "$BUNDLE" \
-        "probe-$ZONE-$iteration" >/dev/null
+    run_probe "probe-$ZONE-$iteration" "$BUNDLE/output-$iteration"
 done
 END=$(date +%s%N)
 AVERAGE_MS=$(((END - START) / 5000000))
-echo "PASS: crun preserved Rauha cgroup/netns/security state; warm bundle launch average ${AVERAGE_MS}ms (n=5)"
+echo "PASS: crun create/enroll/start preserved Rauha containment; warm bundle launch average ${AVERAGE_MS}ms (n=5)"

--- a/tests/security/recovery-probe.sh
+++ b/tests/security/recovery-probe.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Two-phase crash-recovery probe. linux-gate.sh kills and restarts rauhad
+# between prepare and verify while the workload remains live.
+set -euo pipefail
+
+PHASE=${1:-}
+STATE=${2:-}
+RAUHA=${RAUHA_BIN:?RAUHA_BIN is required}
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+POLICY=${RAUHA_TEST_AUDIT_POLICY:-$ROOT/policies/audit.toml}
+IMAGE=${TEST_IMAGE:-alpine:latest}
+
+inode_check_passes() {
+    "$RAUHA" --json zone verify "$1" | jq -e '
+        .checks[]
+        | select(
+            .name == "filesystem:inode_ownership"
+            and .passed == true
+            and (.detail | test("^[1-9][0-9]* rootfs inodes registered$"))
+        )
+    ' >/dev/null
+}
+
+case "$PHASE" in
+    prepare)
+        [ -n "$STATE" ] || { echo "recovery state path is required" >&2; exit 2; }
+        ZONE="test-recovery-$$"
+        cleanup_failed_prepare() {
+            "$RAUHA" zone delete "$ZONE" --force >/dev/null 2>&1 || true
+        }
+        trap cleanup_failed_prepare EXIT
+
+        "$RAUHA" image pull "$IMAGE" >/dev/null
+        "$RAUHA" zone create --name "$ZONE" --policy "$POLICY" >/dev/null
+        CONTAINER=$($RAUHA run --zone "$ZONE" "$IMAGE" /bin/sleep 300)
+        CGROUP="/sys/fs/cgroup/rauha.slice/zone-$ZONE/cgroup.procs"
+        PID=""
+        for _ in $(seq 1 30); do
+            PID=$(head -n 1 "$CGROUP" 2>/dev/null || true)
+            [ -n "$PID" ] && break
+            sleep 0.1
+        done
+        [ -n "$PID" ] || { echo "recovery workload never entered its zone cgroup" >&2; exit 1; }
+        inode_check_passes "$ZONE" || { echo "inode ownership was incomplete before restart" >&2; exit 1; }
+        START=$(awk '{print $22}' "/proc/$PID/stat")
+        printf 'zone=%s\ncontainer=%s\npid=%s\nstart=%s\n' \
+            "$ZONE" "$CONTAINER" "$PID" "$START" >"$STATE"
+        trap - EXIT
+        echo "PASS: prepared live recovery workload with verified inode ownership"
+        ;;
+    verify)
+        [ -r "$STATE" ] || { echo "recovery state is missing: $STATE" >&2; exit 2; }
+        ZONE=$(sed -n 's/^zone=//p' "$STATE")
+        PID=$(sed -n 's/^pid=//p' "$STATE")
+        START=$(sed -n 's/^start=//p' "$STATE")
+        [ -n "$ZONE" ] && [ -n "$PID" ] && [ -n "$START" ] || {
+            echo "recovery state is incomplete" >&2
+            exit 2
+        }
+        cleanup_verify() {
+            "$RAUHA" zone delete "$ZONE" --force >/dev/null 2>&1 || true
+        }
+        trap cleanup_verify EXIT
+
+        "$RAUHA" zone list | grep "$ZONE" >/dev/null || { echo "zone metadata was not recovered" >&2; exit 1; }
+        [ -r "/proc/$PID/stat" ] || { echo "live workload was lost during daemon restart" >&2; exit 1; }
+        [ "$(awk '{print $22}' "/proc/$PID/stat")" = "$START" ] || {
+            echo "recovered PID no longer identifies the original workload" >&2
+            exit 1
+        }
+        inode_check_passes "$ZONE" || { echo "inode ownership was not rebuilt after restart" >&2; exit 1; }
+        "$RAUHA" --json zone verify "$ZONE" | jq -e '
+            .checks[] | select(.name == "bpf_membership" and .passed == true)
+        ' >/dev/null
+        echo "PASS: daemon restart rebuilt live cgroup membership and rootfs inode ownership"
+        ;;
+    *)
+        echo "usage: recovery-probe.sh prepare|verify STATE" >&2
+        exit 2
+        ;;
+esac

--- a/tests/security/run.sh
+++ b/tests/security/run.sh
@@ -56,14 +56,21 @@ fingerprint_linux() {
 if [ "${1:-}" = "--gate" ]; then
     [ "$#" -eq 1 ] || { echo "--gate takes no additional arguments" >&2; exit 2; }
     kind=$(sed -n 's/^kind=//p' "$RUNTIME")
+    test_image=$(sed -n 's/^test_image=//p' "$RUNTIME")
+    test_image=${test_image:-alpine:latest}
+    test_secondary_image=$(sed -n 's/^test_secondary_image=//p' "$RUNTIME")
+    test_secondary_image=${test_secondary_image:-busybox:latest}
     case "$kind" in
         linux)
-            exec bash "$ROOT/tests/security/linux-gate.sh"
+            exec env TEST_IMAGE="$test_image" TEST_SECONDARY_IMAGE="$test_secondary_image" \
+                bash "$ROOT/tests/security/linux-gate.sh"
             ;;
         lima)
             instance=$(sed -n 's/^instance=//p' "$RUNTIME")
             [ -n "$instance" ] || { echo "missing Lima instance in $RUNTIME" >&2; exit 2; }
-            exec limactl shell "$instance" -- bash "$ROOT/tests/security/linux-gate.sh"
+            exec limactl shell "$instance" -- env TEST_IMAGE="$test_image" \
+                TEST_SECONDARY_IMAGE="$test_secondary_image" \
+                bash "$ROOT/tests/security/linux-gate.sh"
             ;;
         *)
             echo "invalid or missing security runtime fingerprint; use tests/security/run.sh" >&2
@@ -78,13 +85,15 @@ mkdir -p "$ROOT/.sykli"
 RUN_ID=$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')
 if [ "$(uname -s)" = Linux ]; then
     {
-        printf 'run_id=%s\nkind=linux\n' "$RUN_ID"
+        printf 'run_id=%s\nkind=linux\ntest_image=%s\ntest_secondary_image=%s\n' \
+            "$RUN_ID" "${TEST_IMAGE:-alpine:latest}" "${TEST_SECONDARY_IMAGE:-busybox:latest}"
         fingerprint_linux
     } >"$RUNTIME"
 else
     instance=$(select_lima)
     {
-        printf 'run_id=%s\nkind=lima\ninstance=%s\n' "$RUN_ID" "$instance"
+        printf 'run_id=%s\nkind=lima\ninstance=%s\ntest_image=%s\ntest_secondary_image=%s\n' \
+            "$RUN_ID" "$instance" "${TEST_IMAGE:-alpine:latest}" "${TEST_SECONDARY_IMAGE:-busybox:latest}"
         limactl shell "$instance" -- bash -c "$(declare -f fingerprint_linux); fingerprint_linux"
     } >"$RUNTIME"
 fi


### PR DESCRIPTION
## Summary

- delegate OCI construction to crun using create → trusted cgroup enrollment → start, with pidfd supervision and crash recovery
- enforce default-deny zone networking, contained OCI extraction, zero-capability semantics, read-only roots, safe writable mounts/devices, and policy-driven seccomp
- bind digest-pinned admission and Ed25519-signed execution receipts to policy, inputs, outputs, enforcement totals, and dropped events
- add adversarial host-impact, recovery, OCI-executor, IPv4/IPv6, and receipt-verification probes plus a measured Wasm-tier experiment
- keep Rust 1.98 Clippy strict for handwritten code while scoping generated-client lints, and update audited `h2`, `anyhow`, and `rand` releases

## Validation

Exact tree `db5a37a49607075f37a820a7cdcab8c398623c4f` passed isolated Toimija gates:

- `rust-format`: `gatercpt_c03aa74cddb01833aa388c03cf290afd053249418ff165dc39de54a175fbb0c5`
- `rust-unit`: `gatercpt_0d5bf97fe1bc235fd407b249fa080b4b20aced81435d4bf414c5729950e8c565` (91 tests)
- `sykli-security`: `gatercpt_17cf6d4ebe9230239688b91fa3111d41fe1c828ffdc5e7a397db59fff568d3ef` (55 oracle cases, networking, recovery, receipt verification, warm crun launch 11 ms)
- `cargo audit`: zero vulnerabilities; three pre-existing allowed transitive warnings remain

## Known blockers

Safe explicit user namespaces remain blocked on the pinned crun 1.14.1/runtime-storage combination: making the rootfs private after entering the target user namespace fails with EPERM for overlay and copied rootfs. runc is absent, and this change deliberately does not use crun’s unsafe `--no-pivot` escape hatch.

GitHub privileged CI also needs explicit cross-repository read credentials for the private `false-systems/sykli` revision. Local locked Sykli/Lima validation above is green; the workflow fails before execution because the repository has no Sykli Actions credential.