### PR TITLE
ci: move the quality job to hosted; the ebpf job stays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   quality:
     name: Workspace quality
-    runs-on: arc-arm64
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
@@ -40,7 +40,7 @@ jobs:
 
   ebpf:
     name: eBPF build
-    runs-on: arc-arm64
+    runs-on: arc-arm64   # stays: loads eBPF, needs a kernel a hosted runner does not give
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
rauha is **public**, so GitHub Actions is free and unlimited here — the 2026-09-09 billing stop only hit private repos. Running on `arc-arm64` bought nothing, and it put fork PRs on a cluster runner pod whose `dind` sidecar is privileged.

**But this is a split, not a move.** The two jobs are not alike, and an adversarial review of the original "move it all" recommendation is what caught that.

| job | destination | why |
|---|---|---|
| `quality` | `ubuntu-24.04-arm` | fmt, clippy, tests — portable Rust, no kernel dependency |
| `ebpf` | **stays on `arc-arm64`** | loads eBPF programs |
| `privileged.yml` | **untouched** | requires BPF LSM in the kernel's active LSM list |

On `ebpf`: a hosted Ubuntu VM does give root, so this is not automatically impossible — but that is a measurement to take, not an assumption to publish. It stays put with a comment explaining why.

On `privileged.yml`: `tests/security/linux-gate.sh` checks `/sys/kernel/security/lsm` for `bpf` in the active LSM list. No GitHub-hosted runner offers that. It is a genuine self-hosted requirement.

## Residual exposure

A public repo with *any* job on a shared self-hosted runner is what GitHub warns against. This reduces it without removing it — recorded in false-systems/false-infra#207, where the real options are an ephemeral runner destroyed per job, or one isolated from the rest of the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)